### PR TITLE
add an optional extra on errors

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -7,8 +7,9 @@ module.exports = function (classes){
   var Errors = {};
 
   Errors.AbstractError = classes.ES5Class.$define('AbstractError', {
-    construct: function(message){
+    construct: function(message, extra){
       this.name = this.$class.$className;
+      this.extra = extra || {};
       this.message = message || this.$class.$className;
       Error.captureStackTrace(this, this.$class);
     },


### PR DESCRIPTION
It's pretty common to have an extra on loggers and so error should have an 'extra' argument to send more information to the logger. The extra is not returned to the client, only for internal use.
#### winston

winston.log('info', 'Test Log Message', { anything: 'This is metadata' });
#### ravenjs

client.captureMessage("Another message", {level: 'info', extra: {'key': 'value'}})
#### logging facility for Python

'The second keyword argument is extra which can be used to pass a dictionary…
