### PR TITLE
Stringify decoded params for debug trace.

### DIFF
--- a/src/endpoint.js
+++ b/src/endpoint.js
@@ -53,7 +53,7 @@ module.exports = function (classes){
       },
       handleCall: function (decoded, conn, callback){
         EventEmitter.trace('<--', 'Request (id ' + decoded.id + '): ' +
-          decoded.method + '(' + decoded.params.join(', ') + ')');
+          decoded.method + '(' + JSON.stringify(decoded.params) + ')');
 
         if (!this.functions.hasOwnProperty(decoded.method)) {
           callback(new Error.MethodNotFound('Unknown RPC call "' + decoded.method + '"'));


### PR DESCRIPTION
According to http://www.jsonrpc.org/specification#parameter_structures
paramaters may also be an object. As object do not have a join method,
use JSON.stringify() instead.
