### PR TITLE
fix memory leak, which appears in case of multiple parallel requests 

### DIFF
--- a/src/http-server-connection.js
+++ b/src/http-server-connection.js
@@ -13,7 +13,11 @@ module.exports = function (classes){
       this.res = res;
       this.isStreaming = false;
 
-      this.res.connection.on('end', function responseEnd(){
+      this.res.on('finish', function responseEnd(){
+        self.emit('end');
+      });
+
+      this.res.on('close', function responseEnd(){
         self.emit('end');
       });
     },


### PR DESCRIPTION
In the case of simultaneous request the number event listeners on res.connection 'end' increases, depending by the amount of traffic. This patch will avoid this behavior.       
