### PR TITLE
allow ids as string types

### DIFF
--- a/src/event-emitter.js
+++ b/src/event-emitter.js
@@ -18,9 +18,10 @@ module.exports = function (classes){
      * @param {Object} request
      * @return {Boolean}
      */
-    hasId : function (request){
+    hasId : function (request) {
       return request && typeof request['id'] !== 'undefined' &&
-        (typeof(request['id']) === 'number' && /^\-?\d+$/.test(request['id']) || typeof(request['id'] === 'string'));
+      (typeof(request['id']) === 'number' && /^\-?\d+$/.test(request['id']) ||
+       typeof(request['id']) === 'string' || request['id'] === null);
     }
   }).$inherit(require('eventemitter3').EventEmitter, []);
 

--- a/src/event-emitter.js
+++ b/src/event-emitter.js
@@ -13,12 +13,14 @@ module.exports = function (classes){
       return msg;
     },
     /**
-     * Check if current request has an integer id
+     * Check if current request has an id adn it is of type integer (non fractional) or string.
+     *
      * @param {Object} request
      * @return {Boolean}
      */
     hasId : function (request){
-      return request && typeof request['id'] !== 'undefined' && /^\-?\d+$/.test(request['id']);
+      return request && typeof request['id'] !== 'undefined' &&
+        (typeof(request['id']) === 'number' && /^\-?\d+$/.test(request['id']) || typeof(request['id'] === 'string'));
     }
   }).$inherit(require('eventemitter3').EventEmitter, []);
 

--- a/test/jsonrpc-test.js
+++ b/test/jsonrpc-test.js
@@ -174,6 +174,20 @@ module.exports = {
       expect(decoded.result).to.equal('Hello, World!');
     },
 
+    'Simple synchronous echo with id as null': function (){
+      var testJSON = '{ "method": "echo", "params": ["Hello, World!"], "id": null }';
+      var req = new MockRequest('POST');
+      var res = new MockResponse();
+      server.handleHttp(req, res);
+      req.emit('data', testJSON);
+      req.emit('end');
+      expect(res.httpCode).to.equal(200);
+      var decoded = JSON.parse(res.httpBody);
+      expect(decoded.id).to.equal(null);
+      expect(decoded.error).to.equal(undefined);
+      expect(decoded.result).to.equal('Hello, World!');
+    },
+
     'Simple synchronous echo with string as id': function (){
       var testJSON = '{ "method": "echo", "params": ["Hello, World!"], "id": "test" }';
       var req = new MockRequest('POST');

--- a/test/jsonrpc-test.js
+++ b/test/jsonrpc-test.js
@@ -174,6 +174,20 @@ module.exports = {
       expect(decoded.result).to.equal('Hello, World!');
     },
 
+    'Simple synchronous echo with string as id': function (){
+      var testJSON = '{ "method": "echo", "params": ["Hello, World!"], "id": "test" }';
+      var req = new MockRequest('POST');
+      var res = new MockResponse();
+      server.handleHttp(req, res);
+      req.emit('data', testJSON);
+      req.emit('end');
+      expect(res.httpCode).to.equal(200);
+      var decoded = JSON.parse(res.httpBody);
+      expect(decoded.id).to.equal('test');
+      expect(decoded.error).to.equal(undefined);
+      expect(decoded.result).to.equal('Hello, World!');
+    },
+
     'Using promise': function (){
       // Expose a function that just returns a promise that we can control.
       var callbackRef = null;


### PR DESCRIPTION
according to the json-rpc specification at http://www.jsonrpc.org/specification:

id
An identifier established by the Client that MUST contain a String, Number, or NULL value if included. If it is not included it is assumed to be a notification. The value SHOULD normally not be Null [1] and Numbers SHOULD NOT contain fractional parts [2]

this fix makes it possible to use a string as an id