### PR TITLE
Allows to send 0/false values as a result

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -212,7 +212,7 @@ module.exports = function (classes) {
 
               response = {
                 'jsonrpc': '2.0',
-                'result': typeof(result) === 'undefined' ? null : result;
+                'result': typeof(result) === 'undefined' ? null : result
               };
             }
 

--- a/src/server.js
+++ b/src/server.js
@@ -212,7 +212,7 @@ module.exports = function (classes) {
 
               response = {
                 'jsonrpc': '2.0',
-                'result': result || null
+                'result': typeof(result) === 'undefined' ? null : result;
               };
             }
 


### PR DESCRIPTION
According to the json-rpc-2 specs result can be Number, Boolean, String and Null. With result || null 
expression, we can not send 0 or false values. So, with current pull request this should be fixed.
