### PR TITLE
Improve _checkAuth function to return promise from authHandler

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,20 +19,23 @@
   ],
   "license": "MIT",
   "author": {
-      "name": "Eric Florenzano",
-      "url": "eflorenzano.com"
+    "name": "Eric Florenzano",
+    "url": "eflorenzano.com"
   },
-  "maintainers": [{
+  "maintainers": [
+    {
       "name": "Paulo Cesar",
       "url": "https://github.com/pocesar"
-  }],
+    }
+  ],
   "dependencies": {
-    "jsonparse": "1.x.x",
+    "bluebird": "^3.4.6",
     "debug": "2.x.x",
-    "lodash": "3.x.x",
     "es5class": "2.x.x",
-    "faye-websocket": "0.x.x",
     "eventemitter3": "1.x.x",
+    "faye-websocket": "0.x.x",
+    "jsonparse": "1.x.x",
+    "lodash": "3.x.x",
     "object-assign": "4.x"
   },
   "engines": {

--- a/src/server.js
+++ b/src/server.js
@@ -152,14 +152,9 @@ module.exports = function (classes) {
                   self._handleUnauthorized(req, socket);
                 }
               }).catch(function (err) { 
-                // should be some other error, it was thrown while
-                // trying to make the authorization or to
-                // handle the websocket
-
-                // TODO: improve error handling/logging by providing the exact
-                // error
-                console.log('http upgrade connection ' + err);
-                self._handleUnauthorized(req, socket);
+                // handle internal server error from Check Authorization
+                classes.EventEmitter.trace('<--', 'Internal Server Error');
+                Server.handleHttpError(req, socket, new Error.InternalError(err.message), self.opts.headers);  
               });
             }
           });
@@ -330,9 +325,9 @@ module.exports = function (classes) {
             return;
           }
         }).catch(function (err) {
-          // TODO: improve error handling/logging by providing the exact error
-          console.log('handle http ' + err);
-          self._handleUnauthorized(req, res);
+          // handle Internal Server Error from Check authorization
+          classes.EventEmitter.trace('<--', 'Internal Server Error');
+          Server.handleHttpError(req, res, new Error.InternalError(err.message), self.opts.headers);
           return;
         });
       },

--- a/test/jsonrpc-test-authorization.js
+++ b/test/jsonrpc-test-authorization.js
@@ -5,7 +5,9 @@ var
   Promise = require('bluebird'),
   rpc = require('../src/jsonrpc.js'),
   Errors = rpc.Error,
-  server, client, serverHandle;
+  server, client, serverHandle,
+  noCookieValueErrorMessage = 'no cookie value',
+  noTokenValueErrorMessage = 'no token value';
 
 module.exports = {
   'Json-Rpc2 Authorization -': { 
@@ -276,7 +278,7 @@ module.exports = {
         // Cookie Authorization
         server.enableCookieAuth(function (cookieValue, callback) {
           if (!cookieValue) {
-            return callback(new Error('no cookie value'), null);
+            return callback(new Error(noCookieValueErrorMessage), null);
           }
           return callback(null, (cookieValue === 'validCookieValue'));
         });
@@ -339,7 +341,7 @@ module.exports = {
         server.enableCookieAuth(function (cookieValue) {
           return new Promise(function (resolve, reject) {
             if (!cookieValue) {
-              reject(new Error('no cookie value'));
+              reject(new Error(noCookieValueErrorMessage));
             }
 
             resolve(cookieValue === 'validCookieValue');
@@ -465,7 +467,7 @@ module.exports = {
         // Bearer (JWT) Authorization
         server.enableJWTAuth(function (tokenValue, callback) {
           if (!tokenValue) {
-            return callback(new Error('no token value'), null);
+            return callback(new Error(noTokenValueErrorMessage), null);
           }
           return callback(null, (tokenValue === 'validTokenValue'));
         });
@@ -527,7 +529,7 @@ module.exports = {
         // Bearer (JWT) Authorization
         server.enableJWTAuth(function (tokenValue, callback) {
          if (!tokenValue) {
-            return callback(new Error('no token value'), null);
+            return callback(new Error(noTokenValueErrorMessage), null);
           }
           return callback(null, (tokenValue === 'validTokenValue'));
         });
@@ -638,7 +640,7 @@ module.exports = {
         });
       },
 
-      'basic/cookie - different type - should return -32602 Unauthorized': function (done) {
+      'basic/cookie - different type - should return -32603 Unauthorized': function (done) {
         server.setAuthType('basic');
         client.setAuthType('cookie');
 
@@ -922,13 +924,13 @@ module.exports = {
         server.enableBasicAuth('user', 'pass');
         server.enableCookieAuth(function (cookieValue, callback) {
           if (!cookieValue) {
-            return callback(new Error('no cookie value'), null);
+            return callback(new Error(noCookieValueErrorMessage), null);
           }
           return callback(null, (cookieValue === 'validCookieValue'));
         });
         server.enableJWTAuth(function (tokenValue, callback) {
           if (!tokenValue) {
-            return callback(new Error('no token value'), null);
+            return callback(new Error(noTokenValueErrorMessage), null);
           }
           return callback(null, (tokenValue === 'validTokenValue'));
         });
@@ -1019,7 +1021,7 @@ module.exports = {
         });
       },
 
-      'basic/cookie - switch only server - should return -32602 Unauthorized': function (done) {
+      'basic/cookie - switch only server - should return -32603 InternalError': function (done) {
         server.setAuthType('basic');
         client.setAuthType('basic');
 
@@ -1038,8 +1040,8 @@ module.exports = {
           // Should return Unauthorized
           client.call('echo', params, function (err, result) {
             expect(result).to.equal(undefined);
-            expect(err.code).to.equal((new Errors.InvalidParams()).code);
-            expect(err.message).to.be.string('Unauthorized');
+            expect(err.code).to.equal((new Errors.InternalError()).code);
+            expect(err.message).to.be.string(noCookieValueErrorMessage);
 
             done();
           });
@@ -1175,7 +1177,7 @@ module.exports = {
         });
       },
 
-      'cookie/bearer(jwt) - different type - should return -32602 Unauthorized': function (done) {
+      'cookie/bearer(jwt) - different type - should return -32603 InternalError': function (done) {
         server.setAuthType('cookie');
         client.setAuthType('jwt');
 
@@ -1183,14 +1185,14 @@ module.exports = {
 
         client.call('echo', params, function (err, result) {
           expect(result).to.equal(undefined);
-          expect(err.code).to.equal((new Errors.InvalidParams()).code);
-          expect(err.message).to.be.string('Unauthorized');
+          expect(err.code).to.equal((new Errors.InternalError()).code);
+          expect(err.message).to.be.string(noCookieValueErrorMessage);
 
           done();
         });
       },
 
-      'cookie/bearer(jwt) - switch only client - should return -32602 Unauthorized': function (done) {
+      'cookie/bearer(jwt) - switch only client - should return -32603 InternalError': function (done) {
         server.setAuthType('cookie');
         client.setAuthType('cookie');
 
@@ -1209,15 +1211,15 @@ module.exports = {
           // Should return Unauthorized
           client.call('echo', params, function (err, result) {
             expect(result).to.equal(undefined);
-            expect(err.code).to.equal((new Errors.InvalidParams()).code);
-            expect(err.message).to.be.string('Unauthorized');
+            expect(err.code).to.equal((new Errors.InternalError()).code);
+            expect(err.message).to.be.string(noCookieValueErrorMessage);
 
             done();
           });
         });
       },
 
-      'cookie/bearer(jwt) - switch only server - should return -32602 Unauthorized': function (done) {
+      'cookie/bearer(jwt) - switch only server - should return -32603 InternalError': function (done) {
         server.setAuthType('cookie');
         client.setAuthType('cookie');
 
@@ -1236,8 +1238,8 @@ module.exports = {
           // Should return Unauthorized
           client.call('echo', params, function (err, result) {
             expect(result).to.equal(undefined);
-            expect(err.code).to.equal((new Errors.InvalidParams()).code);
-            expect(err.message).to.be.string('Unauthorized');
+            expect(err.code).to.equal((new Errors.InternalError()).code);
+            expect(err.message).to.be.string(noTokenValueErrorMessage);
 
             done();
           });
@@ -1262,7 +1264,7 @@ module.exports = {
         server.enableCookieAuth(function (cookieValue) {
           return new Promise(function (resolve, reject) {
             if (!cookieValue) {
-              reject(new Error('no cookie value'));
+              reject(new Error(noCookieValueErrorMessage));
             }
 
             resolve(cookieValue === 'validCookieValue');
@@ -1271,7 +1273,7 @@ module.exports = {
         server.enableJWTAuth(function (tokenValue) {
           return new Promise(function (resolve, reject) {
             if (!tokenValue) {
-              reject(new Error('no token value'));
+              reject(new Error(noTokenValueErrorMessage));
             }
 
             resolve(tokenValue === 'validTokenValue');
@@ -1364,7 +1366,7 @@ module.exports = {
         });
       },
 
-      'basic/cookie - switch only server - should return -32602 Unauthorized': function (done) {
+      'basic/cookie - switch only server - should return -32603 InternalError': function (done) {
         server.setAuthType('basic');
         client.setAuthType('basic');
 
@@ -1383,8 +1385,8 @@ module.exports = {
           // Should return Unauthorized
           client.call('echo', params, function (err, result) {
             expect(result).to.equal(undefined);
-            expect(err.code).to.equal((new Errors.InvalidParams()).code);
-            expect(err.message).to.be.string('Unauthorized');
+            expect(err.code).to.equal((new Errors.InternalError()).code);
+            expect(err.message).to.be.string(noCookieValueErrorMessage);
 
             done();
           });
@@ -1520,7 +1522,7 @@ module.exports = {
         });
       },
 
-      'cookie/bearer(jwt) - different type - should return -32602 Unauthorized': function (done) {
+      'cookie/bearer(jwt) - different type - should return -32603 InternalError': function (done) {
         server.setAuthType('cookie');
         client.setAuthType('jwt');
 
@@ -1528,14 +1530,14 @@ module.exports = {
 
         client.call('echo', params, function (err, result) {
           expect(result).to.equal(undefined);
-          expect(err.code).to.equal((new Errors.InvalidParams()).code);
-          expect(err.message).to.be.string('Unauthorized');
+          expect(err.code).to.equal((new Errors.InternalError()).code);
+          expect(err.message).to.be.string(noCookieValueErrorMessage);
 
           done();
         });
       },
 
-      'cookie/bearer(jwt) - switch only client - should return -32602 Unauthorized': function (done) {
+      'cookie/bearer(jwt) - switch only client - should return -32603 InternalError': function (done) {
         server.setAuthType('cookie');
         client.setAuthType('cookie');
 
@@ -1554,15 +1556,15 @@ module.exports = {
           // Should return Unauthorized
           client.call('echo', params, function (err, result) {
             expect(result).to.equal(undefined);
-            expect(err.code).to.equal((new Errors.InvalidParams()).code);
-            expect(err.message).to.be.string('Unauthorized');
+            expect(err.code).to.equal((new Errors.InternalError()).code);
+            expect(err.message).to.be.string(noCookieValueErrorMessage);
 
             done();
           });
         });
       },
 
-      'cookie/bearer(jwt) - switch only server - should return -32602 Unauthorized': function (done) {
+      'cookie/bearer(jwt) - switch only server - should return -32603 InternalError': function (done) {
         server.setAuthType('cookie');
         client.setAuthType('cookie');
 
@@ -1581,8 +1583,8 @@ module.exports = {
           // Should return Unauthorized
           client.call('echo', params, function (err, result) {
             expect(result).to.equal(undefined);
-            expect(err.code).to.equal((new Errors.InvalidParams()).code);
-            expect(err.message).to.be.string('Unauthorized');
+            expect(err.code).to.equal((new Errors.InternalError()).code);
+            expect(err.message).to.be.string(noTokenValueErrorMessage);
 
             done();
           });

--- a/test/jsonrpc-test-authorization.js
+++ b/test/jsonrpc-test-authorization.js
@@ -2,13 +2,14 @@
 
 var
   expect = require('expect.js'),
+  Promise = require('bluebird'),
   rpc = require('../src/jsonrpc.js'),
   Errors = rpc.Error,
   server, client, serverHandle;
 
 module.exports = {
-  'Json-Rpc2 Authorization -': {
-    'Deprecated Basic -': {
+  'Json-Rpc2 Authorization -': { 
+    'Deprecated Basic - sync authHandler -': {
       beforeEach: function () {
         // Server
         server = rpc.Server.$create({
@@ -20,7 +21,7 @@ module.exports = {
           callback(null, args[0]);
         });
 
-        server.expose('throw_error', function (args, opts, callback) {
+        server.expose('throw_error', function () {
           throw new Errors.InternalError();
         });
 
@@ -42,6 +43,7 @@ module.exports = {
         var message = ['Hello, Authorization!'];
 
         client.call('throw_error', message, function (err, result) {
+          expect(result).to.equal(undefined);
           expect(err.code).to.equal((new Errors.InternalError()).code);
           expect(err.message).to.be.string('InternalError');
 
@@ -112,7 +114,7 @@ module.exports = {
       }
     },
 
-    'Basic -': {
+    'Basic - sync authHandler -': {
       beforeEach: function () {
         // Server
         server = rpc.Server.$create({
@@ -184,23 +186,22 @@ module.exports = {
       },
 
       'client basicAuth function - should return -32602 Unauthorized': function (done) {
-      // Client
-      client = rpc.Client.$create(8088, 'localhost');
-      client.basicAuth('wrong-user', 'wrong-pass');
-      var message = ['Hello, Authorization!'];
+        // Client
+        client = rpc.Client.$create(8088, 'localhost');
+        client.basicAuth('wrong-user', 'wrong-pass');
+        var message = ['Hello, Authorization!'];
 
-      client.call('echo', message, function (err, result) {
-        expect(result).to.equal(undefined);
-        expect(err.code).to.equal((new Errors.InvalidParams()).code);
-        expect(err.message).to.be.string('Unauthorized');
+        client.call('echo', message, function (err, result) {
+          expect(result).to.equal(undefined);
+          expect(err.code).to.equal((new Errors.InvalidParams()).code);
+          expect(err.message).to.be.string('Unauthorized');
 
-        done();
-      });
-
-    }
+          done();
+        });
+      }
     },
-
-    'Cookie -': {
+    
+    'Cookie - sync authHandler -': {
       beforeEach: function () {
         // Server
         server = rpc.Server.$create({
@@ -244,23 +245,151 @@ module.exports = {
       },
 
       'client cookieAuth function - should return -32602 Unauthorized': function (done) {
-      // Client
-      client = rpc.Client.$create(8088, 'localhost');
-      client.cookieAuth('wrongCookieValue');
-      var message = ['Hello, Authorization!'];
+        // Client
+        client = rpc.Client.$create(8088, 'localhost');
+        client.cookieAuth('wrongCookieValue');
+        var message = ['Hello, Authorization!'];
 
-      client.call('echo', message, function (err, result) {
-        expect(result).to.equal(undefined);
-        expect(err.code).to.equal((new Errors.InvalidParams()).code);
-        expect(err.message).to.be.string('Unauthorized');
+        client.call('echo', message, function (err, result) {
+          expect(result).to.equal(undefined);
+          expect(err.code).to.equal((new Errors.InvalidParams()).code);
+          expect(err.message).to.be.string('Unauthorized');
 
-        done();
-      });
+          done();
+        });
+      }
+    },
+    
+    'Cookie - callback authHandler -': {
+      beforeEach: function () {
+        // Server
+        server = rpc.Server.$create({
+          websocket: true
+        });
 
-    }
-  },
+        server.expose('echo', function (args, opts, callback) {
+          // callback(err, result)
+          callback(null, args[0]);
+        });
 
-    'Bearer (JWT) -': {
+        serverHandle = server.listen(8088, 'localhost');
+        // Cookie Authorization
+        server.enableCookieAuth(function (cookieValue, callback) {
+          if (!cookieValue) {
+            return callback(new Error('no cookie value'), null);
+          }
+          return callback(null, (cookieValue === 'validCookieValue'));
+        });
+      },
+
+      afterEach: function () {
+        serverHandle.close();
+        serverHandle = null;
+        server = null;
+        client = null;
+      },
+
+      'client cookieAuth function - should return 200 OK': function (done) {
+        // Client
+        client = rpc.Client.$create(8088, 'localhost');
+        client.cookieAuth('validCookieValue');
+        var message = ['Hello, Authorization!'];
+
+        client.call('echo', message, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(message[0]);
+
+          done();
+        });
+      },
+
+      'client cookieAuth function - should return -32602 Unauthorized': function (done) {
+        // Client
+        client = rpc.Client.$create(8088, 'localhost');
+        client.cookieAuth('wrongCookieValue');
+        var message = ['Hello, Authorization!'];
+
+        client.call('echo', message, function (err, result) {
+          expect(result).to.equal(undefined);
+          expect(err.code).to.equal((new Errors.InvalidParams()).code);
+          expect(err.message).to.be.string('Unauthorized');
+
+          done();
+        });
+      }
+    },
+
+    'Cookie - promise authHandler -': {
+      beforeEach: function () {
+        // Server
+        server = rpc.Server.$create({
+          websocket: true
+        });
+
+        server.expose('echo', function (args, opts, callback) {
+          // callback(err, result)
+          callback(null, args[0]);
+        });
+
+        serverHandle = server.listen(8088, 'localhost');
+        // Cookie Authorization
+        server.enableCookieAuth(function (cookieValue) {
+          return new Promise(function (resolve, reject) {
+            if (!cookieValue) {
+              reject(new Error('no cookie value'));
+            }
+
+            resolve(cookieValue === 'validCookieValue');
+          });
+            
+          
+        });
+      },
+
+      afterEach: function () {
+        serverHandle.close();
+        serverHandle = null;
+        server = null;
+        client = null;
+      },
+
+      'client cookieAuth function - should return 200 OK': function (done) {
+        // Client
+        client = rpc.Client.$create(8088, 'localhost');
+        client.cookieAuth('validCookieValue');
+        var message = ['Hello, Authorization!'];
+
+        client.call('echo', message, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(message[0]);
+
+          done();
+        });
+      },
+
+      'client cookieAuth function - should return -32602 Unauthorized': function (done) {
+        // Client
+        client = rpc.Client.$create(8088, 'localhost');
+        client.cookieAuth('wrongCookieValue');
+        var message = ['Hello, Authorization!'];
+
+        client.call('echo', message, function (err, result) {
+          expect(result).to.equal(undefined);
+          expect(err.code).to.equal((new Errors.InvalidParams()).code);
+          expect(err.message).to.be.string('Unauthorized');
+
+          done();
+        });
+      }
+    },
+    
+    'Bearer (JWT) - sync authHandler -': {
       beforeEach: function () {
       // Server
       server = rpc.Server.$create({
@@ -320,7 +449,131 @@ module.exports = {
         }
     },
 
-    'Mixed -': {
+    'Bearer (JWT) - callback authHandler -': {
+      beforeEach: function () {
+        // Server
+        server = rpc.Server.$create({
+          websocket: true
+        });
+
+        server.expose('echo', function (args, opts, callback) {
+          // callback(err, result)
+          callback(null, args[0]);
+        });
+
+        serverHandle = server.listen(8088, 'localhost');
+        // Bearer (JWT) Authorization
+        server.enableJWTAuth(function (tokenValue, callback) {
+          if (!tokenValue) {
+            return callback(new Error('no token value'), null);
+          }
+          return callback(null, (tokenValue === 'validTokenValue'));
+        });
+      },
+
+      afterEach: function () {
+        serverHandle.close();
+        serverHandle = null;
+        server = null;
+        client = null;
+      },
+
+      'client cookieAuth function - should return 200 OK': function (done) {
+        // Client
+        client = rpc.Client.$create(8088, 'localhost');
+        client.jwtAuth('validTokenValue');
+        var message = ['Hello, Authorization!'];
+
+        client.call('echo', message, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(message[0]);
+
+          done();
+        });
+      },
+
+      'client cookieAuth function - should return -32602 Unauthorized': function (done) {
+        // Client
+        client = rpc.Client.$create(8088, 'localhost');
+        client.jwtAuth('wrongTokenValue');
+        var message = ['Hello, Authorization!'];
+
+        client.call('echo', message, function (err, result) {
+          expect(result).to.equal(undefined);
+          expect(err.code).to.equal((new Errors.InvalidParams()).code);
+          expect(err.message).to.be.string('Unauthorized');
+
+          done();
+        });
+      }
+    },
+
+    'Bearer (JWT) - promise authHandler -': {
+      beforeEach: function () {
+        // Server
+        server = rpc.Server.$create({
+          websocket: true
+        });
+
+        server.expose('echo', function (args, opts, callback) {
+          // callback(err, result)
+          callback(null, args[0]);
+        });
+
+        serverHandle = server.listen(8088, 'localhost');
+        // Bearer (JWT) Authorization
+        server.enableJWTAuth(function (tokenValue, callback) {
+         if (!tokenValue) {
+            return callback(new Error('no token value'), null);
+          }
+          return callback(null, (tokenValue === 'validTokenValue'));
+        });
+      },
+
+      afterEach: function () {
+        serverHandle.close();
+        serverHandle = null;
+        server = null;
+        client = null;
+      },
+
+      'client cookieAuth function - should return 200 OK': function (done) {
+        // Client
+        client = rpc.Client.$create(8088, 'localhost');
+        client.jwtAuth('validTokenValue');
+        var message = ['Hello, Authorization!'];
+
+        client.call('echo', message, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(message[0]);
+
+          done();
+        });
+      },
+
+      'client cookieAuth function - should return -32602 Unauthorized': function (done) {
+        // Client
+        client = rpc.Client.$create(8088, 'localhost');
+        client.jwtAuth('wrongTokenValue');
+        var message = ['Hello, Authorization!'];
+
+        client.call('echo', message, function (err, result) {
+          expect(result).to.equal(undefined);
+          expect(err.code).to.equal((new Errors.InvalidParams()).code);
+          expect(err.message).to.be.string('Unauthorized');
+
+          done();
+        });
+      }
+    },
+
+    'Mixed - sync authHandler -': {
       beforeEach: function () {
         server = rpc.Server.$create({
           websocket: true
@@ -651,6 +904,691 @@ module.exports = {
           });
         });
       }      
+    },
+
+    'Mixed - callback authHandler -': {
+      beforeEach: function () {
+        server = rpc.Server.$create({
+          websocket: true
+        });
+
+        server.expose('echo', function (args, opts, callback) {
+          callback(null, args[0]);
+        });
+
+        serverHandle = server.listen(8088, 'localhost');
+
+        // Server Authorization
+        server.enableBasicAuth('user', 'pass');
+        server.enableCookieAuth(function (cookieValue, callback) {
+          if (!cookieValue) {
+            return callback(new Error('no cookie value'), null);
+          }
+          return callback(null, (cookieValue === 'validCookieValue'));
+        });
+        server.enableJWTAuth(function (tokenValue, callback) {
+          if (!tokenValue) {
+            return callback(new Error('no token value'), null);
+          }
+          return callback(null, (tokenValue === 'validTokenValue'));
+        });
+
+        // Client Authorization
+        client = rpc.Client.$create(8088, 'localhost');
+        client.basicAuth('user', 'pass');
+        client.cookieAuth('validCookieValue');
+        client.jwtAuth('validTokenValue');
+      },
+
+      afterEach: function () {
+        serverHandle.close();
+        serverHandle = null;
+        server = null;
+        client = null;
+      },
+
+      'basic/cookie - switch both - should return 200 OK': function (done) {
+        server.setAuthType('basic');
+        client.setAuthType('basic');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        // We MUST enable promises on the call method!!!
+        client.call('echo', params, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(params[0]);
+
+          // Switch Auth Type (would look better to have promises here)
+          server.setAuthType('cookie');
+          client.setAuthType('cookie');
+
+          client.call('echo', params, function (err, result) {
+            if (err) {
+              return done(new Error(JSON.stringify(err)));
+            }
+
+            expect(JSON.stringify(result)).to.be.string(params[0]);
+
+            done();
+          });
+        });
+      },
+
+      'basic/cookie - different type - should return -32602 Unauthorized': function (done) {
+        server.setAuthType('basic');
+        client.setAuthType('cookie');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        client.call('echo', params, function (err, result) {
+          expect(result).to.equal(undefined);
+          expect(err.code).to.equal((new Errors.InvalidParams()).code);
+          expect(err.message).to.be.string('Unauthorized');
+
+          done();
+        });
+      },
+
+      'basic/cookie - switch only client - should return -32602 Unauthorized': function (done) {
+        server.setAuthType('basic');
+        client.setAuthType('basic');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        client.call('echo', params, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(params[0]);
+
+          // Switch Auth Type Only for the Client
+          client.setAuthType('cookie');
+
+          // Should return Unauthorized
+          client.call('echo', params, function (err, result) {
+            expect(result).to.equal(undefined);
+            expect(err.code).to.equal((new Errors.InvalidParams()).code);
+            expect(err.message).to.be.string('Unauthorized');
+
+            done();
+          });
+        });
+      },
+
+      'basic/cookie - switch only server - should return -32602 Unauthorized': function (done) {
+        server.setAuthType('basic');
+        client.setAuthType('basic');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        client.call('echo', params, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(params[0]);
+
+          // Switch Auth Type Only for the Server
+          server.setAuthType('cookie');
+
+          // Should return Unauthorized
+          client.call('echo', params, function (err, result) {
+            expect(result).to.equal(undefined);
+            expect(err.code).to.equal((new Errors.InvalidParams()).code);
+            expect(err.message).to.be.string('Unauthorized');
+
+            done();
+          });
+        });
+      },
+
+      'basic/bearer(jwt) - switch both - should return 200 OK': function (done) {
+        server.setAuthType('basic');
+        client.setAuthType('basic');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        // We MUST enable promises on the call method!!!
+        client.call('echo', params, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(params[0]);
+
+          // Switch Auth Type
+          server.setAuthType('jwt');
+          client.setAuthType('jwt');
+
+          client.call('echo', params, function (err, result) {
+            if (err) {
+              return done(new Error(JSON.stringify(err)));
+            }
+
+            expect(JSON.stringify(result)).to.be.string(params[0]);
+
+            done();
+          });
+        });
+      },
+
+      'basic/bearer(jwt) - different type - should return -32602 Unauthorized': function (done) {
+        server.setAuthType('basic');
+        client.setAuthType('jwt');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        client.call('echo', params, function (err, result) {
+          expect(result).to.equal(undefined);
+          expect(err.code).to.equal((new Errors.InvalidParams()).code);
+          expect(err.message).to.be.string('Unauthorized');
+
+          done();
+        });
+      },
+
+      'basic/bearer(jwt) - switch only client - should return -32602 Unauthorized': function (done) {
+        server.setAuthType('basic');
+        client.setAuthType('basic');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        client.call('echo', params, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(params[0]);
+
+          // Switch Auth Type Only for the Client
+          client.setAuthType('jwt');
+
+          // Should return Unauthorized
+          client.call('echo', params, function (err, result) {
+            expect(result).to.equal(undefined);
+            expect(err.code).to.equal((new Errors.InvalidParams()).code);
+            expect(err.message).to.be.string('Unauthorized');
+
+            done();
+          });
+        });
+      },
+
+      'basic/bearer(jwt) - switch only server - should return -32602 Unauthorized': function (done) {
+        server.setAuthType('basic');
+        client.setAuthType('basic');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        client.call('echo', params, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(params[0]);
+
+          // Switch Auth Type Only for the Server
+          server.setAuthType('jwt');
+
+          // Should return Unauthorized
+          client.call('echo', params, function (err, result) {
+            expect(result).to.equal(undefined);
+            expect(err.code).to.equal((new Errors.InvalidParams()).code);
+            expect(err.message).to.be.string('Unauthorized');
+
+            done();
+          });
+        });
+      },
+
+      'cookie/bearer(jwt) - switch both - should return 200 OK': function (done) {
+        server.setAuthType('cookie');
+        client.setAuthType('cookie');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        // We MUST enable promises on the call method!!!
+        client.call('echo', params, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(params[0]);
+
+          // Switch Auth Type
+          server.setAuthType('jwt');
+          client.setAuthType('jwt');
+
+          client.call('echo', params, function (err, result) {
+            if (err) {
+              return done(new Error(JSON.stringify(err)));
+            }
+
+            expect(JSON.stringify(result)).to.be.string(params[0]);
+
+            done();
+          });
+        });
+      },
+
+      'cookie/bearer(jwt) - different type - should return -32602 Unauthorized': function (done) {
+        server.setAuthType('cookie');
+        client.setAuthType('jwt');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        client.call('echo', params, function (err, result) {
+          expect(result).to.equal(undefined);
+          expect(err.code).to.equal((new Errors.InvalidParams()).code);
+          expect(err.message).to.be.string('Unauthorized');
+
+          done();
+        });
+      },
+
+      'cookie/bearer(jwt) - switch only client - should return -32602 Unauthorized': function (done) {
+        server.setAuthType('cookie');
+        client.setAuthType('cookie');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        client.call('echo', params, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(params[0]);
+
+          // Switch Auth Type Only for the Client
+          client.setAuthType('jwt');
+
+          // Should return Unauthorized
+          client.call('echo', params, function (err, result) {
+            expect(result).to.equal(undefined);
+            expect(err.code).to.equal((new Errors.InvalidParams()).code);
+            expect(err.message).to.be.string('Unauthorized');
+
+            done();
+          });
+        });
+      },
+
+      'cookie/bearer(jwt) - switch only server - should return -32602 Unauthorized': function (done) {
+        server.setAuthType('cookie');
+        client.setAuthType('cookie');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        client.call('echo', params, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(params[0]);
+
+          // Switch Auth Type Only for the Server
+          server.setAuthType('jwt');
+
+          // Should return Unauthorized
+          client.call('echo', params, function (err, result) {
+            expect(result).to.equal(undefined);
+            expect(err.code).to.equal((new Errors.InvalidParams()).code);
+            expect(err.message).to.be.string('Unauthorized');
+
+            done();
+          });
+        });
+      }      
+    },
+
+    'Mixed - promise authHandler -': {
+      beforeEach: function () {
+        server = rpc.Server.$create({
+          websocket: true
+        });
+
+        server.expose('echo', function (args, opts, callback) {
+          callback(null, args[0]);
+        });
+
+        serverHandle = server.listen(8088, 'localhost');
+
+        // Server Authorization
+        server.enableBasicAuth('user', 'pass');
+        server.enableCookieAuth(function (cookieValue) {
+          return new Promise(function (resolve, reject) {
+            if (!cookieValue) {
+              reject(new Error('no cookie value'));
+            }
+
+            resolve(cookieValue === 'validCookieValue');
+          });
+        });
+        server.enableJWTAuth(function (tokenValue) {
+          return new Promise(function (resolve, reject) {
+            if (!tokenValue) {
+              reject(new Error('no token value'));
+            }
+
+            resolve(tokenValue === 'validTokenValue');
+          });
+        });
+
+        // Client Authorization
+        client = rpc.Client.$create(8088, 'localhost');
+        client.basicAuth('user', 'pass');
+        client.cookieAuth('validCookieValue');
+        client.jwtAuth('validTokenValue');
+      },
+
+      afterEach: function () {
+        serverHandle.close();
+        serverHandle = null;
+        server = null;
+        client = null;
+      },
+
+      'basic/cookie - switch both - should return 200 OK': function (done) {
+        server.setAuthType('basic');
+        client.setAuthType('basic');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        // We MUST enable promises on the call method!!!
+        client.call('echo', params, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(params[0]);
+
+          // Switch Auth Type (would look better to have promises here)
+          server.setAuthType('cookie');
+          client.setAuthType('cookie');
+
+          client.call('echo', params, function (err, result) {
+            if (err) {
+              return done(new Error(JSON.stringify(err)));
+            }
+
+            expect(JSON.stringify(result)).to.be.string(params[0]);
+
+            done();
+          });
+        });
+      },
+
+      'basic/cookie - different type - should return -32602 Unauthorized': function (done) {
+        server.setAuthType('basic');
+        client.setAuthType('cookie');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        client.call('echo', params, function (err, result) {
+          expect(result).to.equal(undefined);
+          expect(err.code).to.equal((new Errors.InvalidParams()).code);
+          expect(err.message).to.be.string('Unauthorized');
+
+          done();
+        });
+      },
+
+      'basic/cookie - switch only client - should return -32602 Unauthorized': function (done) {
+        server.setAuthType('basic');
+        client.setAuthType('basic');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        client.call('echo', params, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(params[0]);
+
+          // Switch Auth Type Only for the Client
+          client.setAuthType('cookie');
+
+          // Should return Unauthorized
+          client.call('echo', params, function (err, result) {
+            expect(result).to.equal(undefined);
+            expect(err.code).to.equal((new Errors.InvalidParams()).code);
+            expect(err.message).to.be.string('Unauthorized');
+
+            done();
+          });
+        });
+      },
+
+      'basic/cookie - switch only server - should return -32602 Unauthorized': function (done) {
+        server.setAuthType('basic');
+        client.setAuthType('basic');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        client.call('echo', params, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(params[0]);
+
+          // Switch Auth Type Only for the Server
+          server.setAuthType('cookie');
+
+          // Should return Unauthorized
+          client.call('echo', params, function (err, result) {
+            expect(result).to.equal(undefined);
+            expect(err.code).to.equal((new Errors.InvalidParams()).code);
+            expect(err.message).to.be.string('Unauthorized');
+
+            done();
+          });
+        });
+      },
+
+      'basic/bearer(jwt) - switch both - should return 200 OK': function (done) {
+        server.setAuthType('basic');
+        client.setAuthType('basic');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        // We MUST enable promises on the call method!!!
+        client.call('echo', params, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(params[0]);
+
+          // Switch Auth Type
+          server.setAuthType('jwt');
+          client.setAuthType('jwt');
+
+          client.call('echo', params, function (err, result) {
+            if (err) {
+              return done(new Error(JSON.stringify(err)));
+            }
+
+            expect(JSON.stringify(result)).to.be.string(params[0]);
+
+            done();
+          });
+        });
+      },
+
+      'basic/bearer(jwt) - different type - should return -32602 Unauthorized': function (done) {
+        server.setAuthType('basic');
+        client.setAuthType('jwt');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        client.call('echo', params, function (err, result) {
+          expect(result).to.equal(undefined);
+          expect(err.code).to.equal((new Errors.InvalidParams()).code);
+          expect(err.message).to.be.string('Unauthorized');
+
+          done();
+        });
+      },
+
+      'basic/bearer(jwt) - switch only client - should return -32602 Unauthorized': function (done) {
+        server.setAuthType('basic');
+        client.setAuthType('basic');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        client.call('echo', params, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(params[0]);
+
+          // Switch Auth Type Only for the Client
+          client.setAuthType('jwt');
+
+          // Should return Unauthorized
+          client.call('echo', params, function (err, result) {
+            expect(result).to.equal(undefined);
+            expect(err.code).to.equal((new Errors.InvalidParams()).code);
+            expect(err.message).to.be.string('Unauthorized');
+
+            done();
+          });
+        });
+      },
+
+      'basic/bearer(jwt) - switch only server - should return -32602 Unauthorized': function (done) {
+        server.setAuthType('basic');
+        client.setAuthType('basic');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        client.call('echo', params, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(params[0]);
+
+          // Switch Auth Type Only for the Server
+          server.setAuthType('jwt');
+
+          // Should return Unauthorized
+          client.call('echo', params, function (err, result) {
+            expect(result).to.equal(undefined);
+            expect(err.code).to.equal((new Errors.InvalidParams()).code);
+            expect(err.message).to.be.string('Unauthorized');
+
+            done();
+          });
+        });
+      },
+
+      'cookie/bearer(jwt) - switch both - should return 200 OK': function (done) {
+        server.setAuthType('cookie');
+        client.setAuthType('cookie');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        // We MUST enable promises on the call method!!!
+        client.call('echo', params, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(params[0]);
+
+          // Switch Auth Type
+          server.setAuthType('jwt');
+          client.setAuthType('jwt');
+
+          client.call('echo', params, function (err, result) {
+            if (err) {
+              return done(new Error(JSON.stringify(err)));
+            }
+
+            expect(JSON.stringify(result)).to.be.string(params[0]);
+
+            done();
+          });
+        });
+      },
+
+      'cookie/bearer(jwt) - different type - should return -32602 Unauthorized': function (done) {
+        server.setAuthType('cookie');
+        client.setAuthType('jwt');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        client.call('echo', params, function (err, result) {
+          expect(result).to.equal(undefined);
+          expect(err.code).to.equal((new Errors.InvalidParams()).code);
+          expect(err.message).to.be.string('Unauthorized');
+
+          done();
+        });
+      },
+
+      'cookie/bearer(jwt) - switch only client - should return -32602 Unauthorized': function (done) {
+        server.setAuthType('cookie');
+        client.setAuthType('cookie');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        client.call('echo', params, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(params[0]);
+
+          // Switch Auth Type Only for the Client
+          client.setAuthType('jwt');
+
+          // Should return Unauthorized
+          client.call('echo', params, function (err, result) {
+            expect(result).to.equal(undefined);
+            expect(err.code).to.equal((new Errors.InvalidParams()).code);
+            expect(err.message).to.be.string('Unauthorized');
+
+            done();
+          });
+        });
+      },
+
+      'cookie/bearer(jwt) - switch only server - should return -32602 Unauthorized': function (done) {
+        server.setAuthType('cookie');
+        client.setAuthType('cookie');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        client.call('echo', params, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(params[0]);
+
+          // Switch Auth Type Only for the Server
+          server.setAuthType('jwt');
+
+          // Should return Unauthorized
+          client.call('echo', params, function (err, result) {
+            expect(result).to.equal(undefined);
+            expect(err.code).to.equal((new Errors.InvalidParams()).code);
+            expect(err.message).to.be.string('Unauthorized');
+
+            done();
+          });
+        });
+      }      
     }
+    
   }
 };

--- a/test/jsonrpc-test.js
+++ b/test/jsonrpc-test.js
@@ -23,7 +23,7 @@ module.exports = {
       };
       server.expose('echo', echo);
 
-      var throw_error = function (args, opts, callback) {
+      var throw_error = function () {
         throw new rpc.Error.InternalError();
       };
       server.expose('throw_error', throw_error);


### PR DESCRIPTION
Solving #28 with this pull request: 

- authHandler now supports sync/callback/promise style implementation
- checkAuth is agnostic of sync/callback/promise authHandler function implementation
- added tests for callback and promise authHandler implementation