### PR TITLE
Refactor handleHttp to support promises 

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -11,5 +11,14 @@
   "devel"   : true,
   "node"    : true,
   "sub"     : true,
-  "quotmark": "single"
+  "quotmark": "single",
+  "globals": {
+    /* MOCHA */
+    "describe"   : false,
+    "it"         : false,
+    "before"     : false,
+    "beforeEach" : false,
+    "after"      : false,
+    "afterEach"  : false
+  }
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -11,14 +11,5 @@
   "devel"   : true,
   "node"    : true,
   "sub"     : true,
-  "quotmark": "single",
-  "globals": {
-    /* MOCHA */
-    "describe"   : false,
-    "it"         : false,
-    "before"     : false,
-    "beforeEach" : false,
-    "after"      : false,
-    "afterEach"  : false
-  }
+  "quotmark": "single"
 }

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ server = null;
 client = null;
 ```
 
-Cookie Authorization Communication
+Bearer(JWT) Authorization Communication
 
 ```js
 var rpc = require('json-rpc2');

--- a/README.md
+++ b/README.md
@@ -86,6 +86,169 @@ server.enableAuth('user', 'pass');
 server.listenRaw(8080, 'localhost');
 ```
 
+Basic Authorization Communication
+
+```js
+var rpc = require('json-rpc2');
+
+var server = rpc.Server.$create({
+    'websocket': true
+});
+
+server.define('echo', function (opts, args, callback) {
+    // function callback(error, result)
+    callback(null, args[0]);
+});
+
+// enableAuth will deprecate in the future
+// enableAuth can still be used, the new function is
+server.enableBasicAuth('user', 'pass');
+serverHandler = server.listen(8088, 'localhost');
+
+client = rpc.Client.$create(8088, 'localhost');
+client.basicAuth('user', 'pass');
+
+var params = ['Hello!, Authorization!'];
+client.call('echo', params, function (err, result) {
+    if (err) { /* do something with error */ }
+    // do something with result
+    console.log(result); // in this case, 'Hello, Authorization!'
+});
+
+serverHandler.close();
+server = null;
+client = null;
+```
+
+Cookie Authorization Communication
+
+```js
+var rpc = require('json-rpc2');
+
+var server = rpc.Server.$create({
+    'websocket': true
+});
+
+server.define('echo', function (opts, args, callback) {
+    // function callback(error, result)
+    callback(null, args[0]);
+});
+
+server.enableCookieAuth(function (cookieValue) {
+    // do call to user service or pass it to middleware
+    return (cookieValue === 'validCookieValue');
+});
+serverHandler = server.listen(8088, 'localhost');
+
+client = rpc.Client.$create(8088, 'localhost');
+client.cookieAuth('validCookieValue');
+
+var params = ['Hello!, Authorization!'];
+client.call('echo', params, function (err, result) {
+    if (err) { /* do something with error */ }
+    // do something with result
+    console.log(result); // in this case, 'Hello, Authorization!'
+});
+
+serverHandler.close();
+server = null;
+client = null;
+```
+
+Cookie Authorization Communication
+
+```js
+var rpc = require('json-rpc2');
+
+var server = rpc.Server.$create({
+    'websocket': true
+});
+
+server.define('echo', function (opts, args, callback) {
+    // function callback(error, result)
+    callback(null, args[0]);
+});
+
+server.enableJWTAuth(function (tokenValue) {
+    // do call to user service or pass it to middleware
+    return (cookieValue === 'validCookieValue');
+});
+serverHandler = server.listen(8088, 'localhost');
+
+client = rpc.Client.$create(8088, 'localhost');
+client.jwtAuth('validTokenValue');
+
+var params = ['Hello!, Authorization!'];
+client.call('echo', params, function (err, result) {
+    if (err) { /* do something with error */ }
+
+    // do something with result
+    console.log(result); // in this case, 'Hello, Authorization!'
+});
+
+serverHandler.close();
+server = null;
+client = null;
+```
+
+Switching between Authorization Methods
+
+```js
+var rpc = require('json-rpc2');
+
+var server = rpc.Server.$create({
+    'websocket': true
+});
+
+server.define('echo', function (opts, args, callback) {
+    // function callback(error, result)
+    callback(null, args[0]);
+});
+
+server.listen(8088, 'localhost');
+
+// Server Authorization
+server.enableBasicAuth('user', 'pass');
+server.enableCookieAuth(function (cookieValue) {
+    // handle cookie validity through a user service or middleware
+    return (cookieValue === 'validCookieValue');
+});
+server.enableJWTAuth(function (tokenValue) {
+    // handle JWT token validity through a user service or middleware
+    return (tokenValue === 'validTokenValue');
+});
+
+// Client Authorization
+client = rpc.Client.$create(8088, 'localhost');
+client.basicAuth('user', 'pass');
+client.cookieAuth('validCookieValue');
+client.jwtAuth('validTokenValue');
+
+// Switch Authorization Methods
+server.setAuthType('basic');
+client.setAuthType('basic');
+
+var params = ['Hello, Authorization!'];
+client.call('echo', params, function (err, result) {
+    if (err) { /* do something with error */ }
+
+    // handle result
+    console.log(result); // in this case, 'Hello, Authorization!' 
+});
+
+server.setAuthType('jwt');
+client.setAuthType('jwt');
+
+client.call('echo', params, function (err, result) {
+    if (err) {/* do something with error */ }
+
+    // handle result
+    console.log(result); // in this case, 'Hello, Authorization!' 
+});
+```
+Switching between server authorization methods will use the provided authorization handler on the server side. 
+Switching between client authorization methods will use the provided authorization credentials. 
+
 ## Extend, overwrite, overload
 
 Any class can be extended, or used as a mixin for new classes, since it uses [ES5Class](http://github.com/pocesar/ES5-Class) module.

--- a/examples/server.js
+++ b/examples/server.js
@@ -51,8 +51,8 @@ server.exposeModule('delayed', {
   }
 );
 
-// or server.enableAuth('myuser', 'secret123');
-server.enableAuth(function(user, password){
+// or server.enableBasicAuth('myuser', 'secret123');
+server.enableBasicAuth(function(user, password){
   return user === 'myuser' && password === 'secret123';
 });
 

--- a/src/client.js
+++ b/src/client.js
@@ -45,22 +45,26 @@ module.exports = function (classes){
       },
       _authHeader: function(headers) {
         switch (this.authType) {
+
           case Authorization.BASIC: 
             if (this.user && this.password) {
               var buff = new Buffer(this.user + ':' + this.password).toString('base64');
               headers['Authorization'] = 'Basic ' + buff;
             }
           break;
+
           case Authorization.COOKIE:
             if (this.cookie) {
               headers['Cookie'] = this.cookie; 
             }
           break;
+
           case Authorization.JWT: 
             if (this.jwtToken) {
               headers['Authorization'] = 'Bearer ' + this.jwtToken;
             }
           break;
+
           default: 
             // Clear Authorization Variables and Headers
             this.jwtToken = null;

--- a/src/client.js
+++ b/src/client.js
@@ -43,10 +43,10 @@ module.exports = function (classes){
           this.authType = Authorization.BASIC;
         }
       },
-      _authHeader: function(headers) {
+      _authHeader  : function(headers) {
         switch (this.authType) {
 
-          case Authorization.BASIC: 
+          case Authorization.BASIC:
             if (this.user && this.password) {
               var buff = new Buffer(this.user + ':' + this.password).toString('base64');
               headers['Authorization'] = 'Basic ' + buff;
@@ -55,7 +55,7 @@ module.exports = function (classes){
 
           case Authorization.COOKIE:
             if (this.cookie) {
-              headers['Cookie'] = this.cookie; 
+              headers['Cookie'] = this.cookie;
             }
           break;
 
@@ -84,8 +84,9 @@ module.exports = function (classes){
        *
        * Use this function before connecting to a server.
        */
-      setAuthType: function(type) {
-        if (type && (type.toLowerCase() in _.values(Authorization))) {
+      setAuthType  : function(type) {
+        type = type.toLowerCase();
+        if (type && (_.values(Authorization).indexOf(type) > -1)) {
           this.authType = type;
         }
       },
@@ -95,10 +96,10 @@ module.exports = function (classes){
        * Sets the Auth Type to Basic and sets the username and password.
        * Must be used before connecting to server. 
        */
-      basicAuth: function(username, password) {
+      basicAuth    : function(username, password) {
         if (username && password) {
           this.authType = Authorization.BASIC;
-          this.username = username;
+          this.user = username;
           this.password = password;
         }
       },
@@ -107,8 +108,12 @@ module.exports = function (classes){
        *
        * Sets the Auth Type to Cookie and sets the cookie header value.
        * Must be used before connecting to a server.
+       *
+       * Server should have a login method (with username and password) which
+       * returns a Set-Cookie Header, and its value has to be copied to the
+       * subsequent requests to the server. (Or set manually by this method)
        */
-      cookieAuth: function(value) { 
+      cookieAuth    : function(value) {
         if (value && false === _.isFunction(value)) {
           this.authType = Authorization.COOKIE;
           this.cookie = value;
@@ -120,7 +125,7 @@ module.exports = function (classes){
        * Set the Auth Type to JWT and sets the JWT token.
        * Must be used before connecting to a server.
        */
-      jwtAuth: function(token) {
+      jwtAuth       : function(token) {
         if (token && false === _.isFunction(token)) {
           this.authType = Authorization.JWT;
           this.jwtToken = token;
@@ -132,7 +137,7 @@ module.exports = function (classes){
        * In HTTP mode, we get to submit exactly one message and receive up to n
        * messages.
        */
-      connectHttp  : function (method, params, opts, callback){
+      connectHttp   : function (method, params, opts, callback){
         if (_.isFunction(opts)) {
           callback = opts;
           opts = {};

--- a/src/client.js
+++ b/src/client.js
@@ -14,19 +14,19 @@ module.exports = function (classes){
     WebSocketConnection = classes.WebSocketConnection,
 
     // Authorization Type Constants
+    // other types to be added
     Authorization = {
-      NONE: 'none'
+      NONE: 'none',
       BASIC: 'basic',
       COOKIE: 'cookie',
       JWT: 'jwt'
-      // other types to be added
     },
 
     /**
      * JSON-RPC Client.
      */
       Client = Endpoint.$define('Client', {
-      construct    : function (super, port, host, user, password){
+      construct    : function ($super, port, host, user, password){
         $super();
 
         // Set Host, Port, Username and Password (if available)

--- a/src/server.js
+++ b/src/server.js
@@ -35,6 +35,8 @@ module.exports = function (classes) {
         this.opts.type = typeof this.opts.type !== 'undefined' ? this.opts.type : 'http';
         this.opts.headers = this.opts.headers || {};
         this.opts.websocket = typeof this.opts.websocket !== 'undefined' ? this.opts.websocket : true;
+
+        // Authorization
         this.authType = Authorization.NONE;
         this.authHandler = null;
         this.basicHandler = null;
@@ -448,6 +450,7 @@ module.exports = function (classes) {
        *     return true;
        *   }
        *
+       *
        */
       enableCookieAuth: function (handler) {
         if (_.isFunction(handler)) {
@@ -481,7 +484,8 @@ module.exports = function (classes) {
        * before switching/setting to another Auth Type.
        */
       setAuthType: function (type) {
-        if (type && (type.toLowerCase() in _.values(Authorization))) {
+        type = type.toLowerCase();
+        if (type && (_.values(Authorization).indexOf(type) > -1)) {
           this.authType = type;
           switch (this.authType) {
             case Authorization.BASIC:

--- a/test/jsonrpc-test-authorization.js
+++ b/test/jsonrpc-test-authorization.js
@@ -6,79 +6,167 @@ var
   Errors = rpc.Error,
   server, client, serverHandle;
 
-describe('Json-Rpc2 Authorization -', function () {
-  describe('Deprecated Basic -', function () {
-    beforeEach(function () {
-      // Server
-      server = rpc.Server.$create({
-        websocket: true
-      });
+module.exports = {
+  'Json-Rpc2 Authorization -': {
+    'Deprecated Basic -': {
+      beforeEach: function () {
+        // Server
+        server = rpc.Server.$create({
+          websocket: true
+        });
 
-      server.expose('echo', function (args, opts, callback) {
-        // callback(err, result)
-        callback(null, args[0]);
-      });
+        server.expose('echo', function (args, opts, callback) {
+          // callback(err, result)
+          callback(null, args[0]);
+        });
 
-      serverHandle = server.listen(8088, 'localhost');
-      // Deprecated Authorization
-      server.enableAuth('user', 'pass');
-    });
+        serverHandle = server.listen(8088, 'localhost');
+        // Deprecated Authorization
+        server.enableAuth('user', 'pass');
+      },
 
-    afterEach(function () {
-      serverHandle.close();
-      serverHandle = null;
-      server = null;
-      client = null;
-    });
+      afterEach: function () {
+        serverHandle.close();
+        serverHandle = null;
+        server = null;
+        client = null;
+      },
 
-    it('client constructor - should return 200 OK', function (done) {
-      // Client
-      client = rpc.Client.$create(8088, 'localhost', 'user', 'pass');
-      var message = ['Hello, Authorization!'];
+      'client constructor - should return 200 OK': function (done) {
+        // Client
+        client = rpc.Client.$create(8088, 'localhost', 'user', 'pass');
+        var message = ['Hello, Authorization!'];
 
-      client.call('echo', message, function (err, result) {
-        if (err) {
-          return done(new Error(JSON.stringify(err)));
-        }
+        client.call('echo', message, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
 
-        expect(JSON.stringify(result)).to.be.string(message[0]);
+          expect(JSON.stringify(result)).to.be.string(message[0]);
 
-        done();
-      });
-    });
+          done();
+        });
+      },
 
-    it('client constructor - should return -32602 Unauthorized', function (done) {
-      // Client
-      client = rpc.Client.$create(8088, 'localhost', 'wrong-user', 'wrong-pass');
-      var message = ['Hello, Authorization!'];
+      'client constructor - should return -32602 Unauthorized': function (done) {
+        // Client
+        client = rpc.Client.$create(8088, 'localhost', 'wrong-user', 'wrong-pass');
+        var message = ['Hello, Authorization!'];
 
-      client.call('echo', message, function (err, result) {
-        expect(result).to.equal(undefined);
-        expect(err.code).to.equal((new Errors.InvalidParams()).code);
-        expect(err.message).to.be.string('Unauthorized');
+        client.call('echo', message, function (err, result) {
+          expect(result).to.equal(undefined);
+          expect(err.code).to.equal((new Errors.InvalidParams()).code);
+          expect(err.message).to.be.string('Unauthorized');
 
-        done();
-      });
-    });
+          done();
+        });
+      },
 
-    it('client basicAuth function - should return 200 OK', function (done) {
-      // Client
-      client = rpc.Client.$create(8088, 'localhost');
-      client.basicAuth('user', 'pass');
-      var message = ['Hello, Authorization!'];
+      'client basicAuth function - should return 200 OK': function (done) {
+        // Client
+        client = rpc.Client.$create(8088, 'localhost');
+        client.basicAuth('user', 'pass');
+        var message = ['Hello, Authorization!'];
 
-      client.call('echo', message, function (err, result) {
-        if (err) {
-          return done(new Error(JSON.stringify(err)));
-        }
+        client.call('echo', message, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
 
-        expect(JSON.stringify(result)).to.be.string(message[0]);
+          expect(JSON.stringify(result)).to.be.string(message[0]);
 
-        done();
-      });
-    });
+          done();
+        });
+      },
 
-    it('client basicAuth function - should return -32602 Unauthorized', function (done) {
+      'client basicAuth function - should return -32602 Unauthorized': function (done) {
+        // Client
+        client = rpc.Client.$create(8088, 'localhost');
+        client.basicAuth('wrong-user', 'wrong-pass');
+        var message = ['Hello, Authorization!'];
+
+        client.call('echo', message, function (err, result) {
+          expect(result).to.equal(undefined);
+          expect(err.code).to.equal((new Errors.InvalidParams()).code);
+          expect(err.message).to.be.string('Unauthorized');
+
+          done();
+        });
+      }
+    },
+
+    'Basic -': {
+      beforeEach: function () {
+        // Server
+        server = rpc.Server.$create({
+          websocket: true
+        });
+
+        server.expose('echo', function (args, opts, callback) {
+          // callback(err, result)
+          callback(null, args[0]);
+        });
+
+        serverHandle = server.listen(8088, 'localhost');
+        // Basic Authorization
+        server.enableBasicAuth('user', 'pass');
+      },
+
+      afterEach: function () {
+        serverHandle.close();
+        serverHandle = null;
+        server = null;
+        client = null;
+      },
+
+      'client constructor - should return 200 OK': function (done) {
+        // Client
+        client = rpc.Client.$create(8088, 'localhost', 'user', 'pass');
+        var message = ['Hello, Authorization!'];
+
+        client.call('echo', message, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(message[0]);
+
+          done();
+        });
+      },
+
+      'client constructor - should return -32602 Unauthorized': function (done) {
+        // Client
+        client = rpc.Client.$create(8088, 'localhost', 'wrong-user', 'wrong-pass');
+        var message = ['Hello, Authorization!'];
+
+        client.call('echo', message, function (err, result) {
+          expect(result).to.equal(undefined);
+          expect(err.code).to.equal((new Errors.InvalidParams()).code);
+          expect(err.message).to.be.string('Unauthorized');
+
+          done();
+        });
+      },
+
+      'client basicAuth function - should return 200 OK': function (done) {
+        // Client
+        client = rpc.Client.$create(8088, 'localhost');
+        client.basicAuth('user', 'pass');
+        var message = ['Hello, Authorization!'];
+
+        client.call('echo', message, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(message[0]);
+
+          done();
+        });
+      },
+
+      'client basicAuth function - should return -32602 Unauthorized': function (done) {
       // Client
       client = rpc.Client.$create(8088, 'localhost');
       client.basicAuth('wrong-user', 'wrong-pass');
@@ -92,144 +180,53 @@ describe('Json-Rpc2 Authorization -', function () {
         done();
       });
 
-    });
-  });
+    }
+    },
 
-  describe('Basic -', function () {
-    beforeEach(function () {
-      // Server
-      server = rpc.Server.$create({
-        websocket: true
-      });
+    'Cookie -': {
+      beforeEach: function () {
+        // Server
+        server = rpc.Server.$create({
+          websocket: true
+        });
 
-      server.expose('echo', function (args, opts, callback) {
-        // callback(err, result)
-        callback(null, args[0]);
-      });
+        server.expose('echo', function (args, opts, callback) {
+          // callback(err, result)
+          callback(null, args[0]);
+        });
 
-      serverHandle = server.listen(8088, 'localhost');
-      // Basic Authorization
-      server.enableBasicAuth('user', 'pass');
-    });
+        serverHandle = server.listen(8088, 'localhost');
+        // Cookie Authorization
+        server.enableCookieAuth(function (cookieValue) {
+          return (cookieValue === 'validCookieValue');
+        });
+      },
 
-    afterEach(function () {
-      serverHandle.close();
-      serverHandle = null;
-      server = null;
-      client = null;
-    });
+      afterEach: function () {
+        serverHandle.close();
+        serverHandle = null;
+        server = null;
+        client = null;
+      },
 
-    it('client constructor - should return 200 OK', function (done) {
-      // Client
-      client = rpc.Client.$create(8088, 'localhost', 'user', 'pass');
-      var message = ['Hello, Authorization!'];
+      'client cookieAuth function - should return 200 OK': function (done) {
+        // Client
+        client = rpc.Client.$create(8088, 'localhost');
+        client.cookieAuth('validCookieValue');
+        var message = ['Hello, Authorization!'];
 
-      client.call('echo', message, function (err, result) {
-        if (err) {
-          return done(new Error(JSON.stringify(err)));
-        }
+        client.call('echo', message, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
 
-        expect(JSON.stringify(result)).to.be.string(message[0]);
+          expect(JSON.stringify(result)).to.be.string(message[0]);
 
-        done();
-      });
-    });
+          done();
+        });
+      },
 
-    it('client constructor - should return -32602 Unauthorized', function (done) {
-      // Client
-      client = rpc.Client.$create(8088, 'localhost', 'wrong-user', 'wrong-pass');
-      var message = ['Hello, Authorization!'];
-
-      client.call('echo', message, function (err, result) {
-        expect(result).to.equal(undefined);
-        expect(err.code).to.equal((new Errors.InvalidParams()).code);
-        expect(err.message).to.be.string('Unauthorized');
-
-        done();
-      });
-    });
-
-    it('client basicAuth function - should return 200 OK', function (done) {
-      // Client
-      client = rpc.Client.$create(8088, 'localhost');
-      client.basicAuth('user', 'pass');
-      var message = ['Hello, Authorization!'];
-
-      client.call('echo', message, function (err, result) {
-        if (err) {
-          return done(new Error(JSON.stringify(err)));
-        }
-
-        expect(JSON.stringify(result)).to.be.string(message[0]);
-
-        done();
-      });
-    });
-
-    it('client basicAuth function - should return -32602 Unauthorized', function (done) {
-      // Client
-      client = rpc.Client.$create(8088, 'localhost');
-      client.basicAuth('wrong-user', 'wrong-pass');
-      var message = ['Hello, Authorization!'];
-
-      client.call('echo', message, function (err, result) {
-        expect(result).to.equal(undefined);
-        expect(err.code).to.equal((new Errors.InvalidParams()).code);
-        expect(err.message).to.be.string('Unauthorized');
-
-        done();
-      });
-
-    });
-  });
-
-  describe('Cookie -', function () {
-    beforeEach(function () {
-      // Server
-      server = rpc.Server.$create({
-        websocket: true
-      });
-
-      server.expose('echo', function (args, opts, callback) {
-        // callback(err, result)
-        callback(null, args[0]);
-      });
-
-      serverHandle = server.listen(8088, 'localhost');
-      // Cookie Authorization
-      server.enableCookieAuth(function (cookieValue) {
-        if (cookieValue === 'validCookieValue') {
-          return true;
-        }
-        return false;
-      });
-    });
-
-    afterEach(function () {
-      serverHandle.close();
-      serverHandle = null;
-      server = null;
-      client = null;
-    });
-
-    it('client cookieAuth function - should return 200 OK', function (done) {
-      // Client
-      client = rpc.Client.$create(8088, 'localhost');
-      client.cookieAuth('validCookieValue');
-      var message = ['Hello, Authorization!'];
-
-      client.call('echo', message, function (err, result) {
-        if (err) {
-          return done(new Error(JSON.stringify(err)));
-        }
-
-        expect(JSON.stringify(result)).to.be.string(message[0]);
-
-        done();
-      });
-    });
-
-    it('client cookieAuth function - should return -32602 Unauthorized', function (done) {
+      'client cookieAuth function - should return -32602 Unauthorized': function (done) {
       // Client
       client = rpc.Client.$create(8088, 'localhost');
       client.cookieAuth('wrongCookieValue');
@@ -243,11 +240,11 @@ describe('Json-Rpc2 Authorization -', function () {
         done();
       });
 
-    });
-  });
+    }
+  },
 
-  describe('Bearer (JWT) -', function () {
-    beforeEach(function () {
+    'Bearer (JWT) -': {
+      beforeEach: function () {
       // Server
       server = rpc.Server.$create({
         websocket: true
@@ -261,21 +258,18 @@ describe('Json-Rpc2 Authorization -', function () {
       serverHandle = server.listen(8088, 'localhost');
       // Bearer (JWT) Authorization
       server.enableJWTAuth(function (tokenValue) {
-        if (tokenValue === 'validTokenValue') {
-          return true;
-        }
-        return false;
+        return (tokenValue === 'validTokenValue');
       });
-    });
+      },
 
-    afterEach(function () {
+      afterEach: function () {
       serverHandle.close();
       serverHandle = null;
       server = null;
       client = null;
-    });
+      },
 
-    it('client cookieAuth function - should return 200 OK', function (done) {
+      'client cookieAuth function - should return 200 OK': function (done) {
       // Client
       client = rpc.Client.$create(8088, 'localhost');
       client.jwtAuth('validTokenValue');
@@ -290,84 +284,265 @@ describe('Json-Rpc2 Authorization -', function () {
 
         done();
       });
-    });
+      },
 
-    it('client cookieAuth function - should return -32602 Unauthorized', function (done) {
-      // Client
-      client = rpc.Client.$create(8088, 'localhost');
-      client.jwtAuth('wrongTokenValue');
-      var message = ['Hello, Authorization!'];
+      'client cookieAuth function - should return -32602 Unauthorized': function (done) {
+          // Client
+          client = rpc.Client.$create(8088, 'localhost');
+          client.jwtAuth('wrongTokenValue');
+          var message = ['Hello, Authorization!'];
 
-      client.call('echo', message, function (err, result) {
-        expect(result).to.equal(undefined);
-        expect(err.code).to.equal((new Errors.InvalidParams()).code);
-        expect(err.message).to.be.string('Unauthorized');
+          client.call('echo', message, function (err, result) {
+            expect(result).to.equal(undefined);
+            expect(err.code).to.equal((new Errors.InvalidParams()).code);
+            expect(err.message).to.be.string('Unauthorized');
 
-        done();
-      });
+            done();
+          });
 
-    });
-  });
-
-  describe('Mixed -', function () {
-    beforeEach(function () {
-      server = rpc.Server.$create({
-        websocket: true
-      });
-
-      server.expose('echo', function (args, opts, callback) {
-        callback(null, args[0]);
-      });
-
-      serverHandle = server.listen(8088, 'localhost');
-
-      // Server Authorization
-      server.enableBasicAuth('user', 'pass');
-      server.enableCookieAuth(function (cookieValue) {
-        if (cookieValue === 'validCookieValue') {
-          return true;
         }
-        return false;
-      });
-      server.enableJWTAuth(function (tokenValue) {
-        if (tokenValue === 'validTokenValue') {
-          return true;
-        }
-        return false;
-      });
+    },
 
-      // Client Authorization
-      client = rpc.Client.$create(8088, 'localhost');
-      client.basicAuth('user', 'pass');
-      client.cookieAuth('validCookieValue');
-      client.jwtAuth('validTokenValue');
-    });
+    'Mixed -': {
+      beforeEach: function () {
+        server = rpc.Server.$create({
+          websocket: true
+        });
 
-    afterEach(function () {
-      serverHandle.close();
-      serverHandle = null;
-      server = null;
-      client = null;
-    });
+        server.expose('echo', function (args, opts, callback) {
+          callback(null, args[0]);
+        });
 
-    it('basic/cookie - switch both - should return 200 OK', function (done) {
-      server.setAuthType('basic');
-      client.setAuthType('basic');
+        serverHandle = server.listen(8088, 'localhost');
 
-      var params = ['Hello! Mixed Authorization'];
+        // Server Authorization
+        server.enableBasicAuth('user', 'pass');
+        server.enableCookieAuth(function (cookieValue) {
+          return (cookieValue === 'validCookieValue');
+        });
+        server.enableJWTAuth(function (tokenValue) {
+          return (tokenValue === 'validTokenValue');
+        });
 
-      // We MUST enable promises on the call method!!!
-      client.call('echo', params, function (err, result) {
-        if (err) {
-          return done(new Error(JSON.stringify(err)));
-        }
+        // Client Authorization
+        client = rpc.Client.$create(8088, 'localhost');
+        client.basicAuth('user', 'pass');
+        client.cookieAuth('validCookieValue');
+        client.jwtAuth('validTokenValue');
+      },
 
-        expect(JSON.stringify(result)).to.be.string(params[0]);
+      afterEach: function () {
+        serverHandle.close();
+        serverHandle = null;
+        server = null;
+        client = null;
+      },
 
-        // Switch Auth Type (would look better to have promises here)
+      'basic/cookie - switch both - should return 200 OK': function (done) {
+        server.setAuthType('basic');
+        client.setAuthType('basic');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        // We MUST enable promises on the call method!!!
+        client.call('echo', params, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(params[0]);
+
+          // Switch Auth Type (would look better to have promises here)
+          server.setAuthType('cookie');
+          client.setAuthType('cookie');
+
+          client.call('echo', params, function (err, result) {
+            if (err) {
+              return done(new Error(JSON.stringify(err)));
+            }
+
+            expect(JSON.stringify(result)).to.be.string(params[0]);
+
+            done();
+          });
+        });
+      },
+
+      'basic/cookie - different type - should return -32602 Unauthorized': function (done) {
+        server.setAuthType('basic');
+        client.setAuthType('cookie');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        client.call('echo', params, function (err, result) {
+          expect(result).to.equal(undefined);
+          expect(err.code).to.equal((new Errors.InvalidParams()).code);
+          expect(err.message).to.be.string('Unauthorized');
+
+          done();
+        });
+      },
+
+      'basic/cookie - switch only client - should return -32602 Unauthorized': function (done) {
+        server.setAuthType('basic');
+        client.setAuthType('basic');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        client.call('echo', params, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(params[0]);
+
+          // Switch Auth Type Only for the Client
+          client.setAuthType('cookie');
+
+          // Should return Unauthorized
+          client.call('echo', params, function (err, result) {
+            expect(result).to.equal(undefined);
+            expect(err.code).to.equal((new Errors.InvalidParams()).code);
+            expect(err.message).to.be.string('Unauthorized');
+
+            done();
+          });
+        });
+      },
+
+      'basic/cookie - switch only server - should return -32602 Unauthorized': function (done) {
+        server.setAuthType('basic');
+        client.setAuthType('basic');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        client.call('echo', params, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(params[0]);
+
+          // Switch Auth Type Only for the Server
+          server.setAuthType('cookie');
+
+          // Should return Unauthorized
+          client.call('echo', params, function (err, result) {
+            expect(result).to.equal(undefined);
+            expect(err.code).to.equal((new Errors.InvalidParams()).code);
+            expect(err.message).to.be.string('Unauthorized');
+
+            done();
+          });
+        });
+      },
+
+      'basic/bearer(jwt) - switch both - should return 200 OK': function (done) {
+        server.setAuthType('basic');
+        client.setAuthType('basic');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        // We MUST enable promises on the call method!!!
+        client.call('echo', params, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(params[0]);
+
+          // Switch Auth Type
+          server.setAuthType('jwt');
+          client.setAuthType('jwt');
+
+          client.call('echo', params, function (err, result) {
+            if (err) {
+              return done(new Error(JSON.stringify(err)));
+            }
+
+            expect(JSON.stringify(result)).to.be.string(params[0]);
+
+            done();
+          });
+        });
+      },
+
+      'basic/bearer(jwt) - different type - should return -32602 Unauthorized': function (done) {
+        server.setAuthType('basic');
+        client.setAuthType('jwt');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        client.call('echo', params, function (err, result) {
+          expect(result).to.equal(undefined);
+          expect(err.code).to.equal((new Errors.InvalidParams()).code);
+          expect(err.message).to.be.string('Unauthorized');
+
+          done();
+        });
+      },
+
+      'basic/bearer(jwt) - switch only client - should return -32602 Unauthorized': function (done) {
+        server.setAuthType('basic');
+        client.setAuthType('basic');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        client.call('echo', params, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(params[0]);
+
+          // Switch Auth Type Only for the Client
+          client.setAuthType('jwt');
+
+          // Should return Unauthorized
+          client.call('echo', params, function (err, result) {
+            expect(result).to.equal(undefined);
+            expect(err.code).to.equal((new Errors.InvalidParams()).code);
+            expect(err.message).to.be.string('Unauthorized');
+
+            done();
+          });
+        });
+      },
+
+      'basic/bearer(jwt) - switch only server - should return -32602 Unauthorized': function (done) {
+        server.setAuthType('basic');
+        client.setAuthType('basic');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        client.call('echo', params, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(params[0]);
+
+          // Switch Auth Type Only for the Server
+          server.setAuthType('jwt');
+
+          // Should return Unauthorized
+          client.call('echo', params, function (err, result) {
+            expect(result).to.equal(undefined);
+            expect(err.code).to.equal((new Errors.InvalidParams()).code);
+            expect(err.message).to.be.string('Unauthorized');
+
+            done();
+          });
+        });
+      },
+
+      'cookie/bearer(jwt) - switch both - should return 200 OK': function (done) {
         server.setAuthType('cookie');
         client.setAuthType('cookie');
 
+        var params = ['Hello! Mixed Authorization'];
+
+        // We MUST enable promises on the call method!!!
         client.call('echo', params, function (err, result) {
           if (err) {
             return done(new Error(JSON.stringify(err)));
@@ -375,97 +550,69 @@ describe('Json-Rpc2 Authorization -', function () {
 
           expect(JSON.stringify(result)).to.be.string(params[0]);
 
+          // Switch Auth Type
+          server.setAuthType('jwt');
+          client.setAuthType('jwt');
+
+          client.call('echo', params, function (err, result) {
+            if (err) {
+              return done(new Error(JSON.stringify(err)));
+            }
+
+            expect(JSON.stringify(result)).to.be.string(params[0]);
+
+            done();
+          });
+        });
+      },
+
+      'cookie/bearer(jwt) - different type - should return -32602 Unauthorized': function (done) {
+        server.setAuthType('cookie');
+        client.setAuthType('jwt');
+
+        var params = ['Hello! Mixed Authorization'];
+
+        client.call('echo', params, function (err, result) {
+          expect(result).to.equal(undefined);
+          expect(err.code).to.equal((new Errors.InvalidParams()).code);
+          expect(err.message).to.be.string('Unauthorized');
+
           done();
         });
-      });
-    });
+      },
 
-    it('basic/cookie - different type - should return -32602 Unauthorized', function (done) {
-      server.setAuthType('basic');
-      client.setAuthType('cookie');
-
-      var params = ['Hello! Mixed Authorization'];
-
-      client.call('echo', params, function (err, result) {
-        expect(result).to.equal(undefined);
-        expect(err.code).to.equal((new Errors.InvalidParams()).code);
-        expect(err.message).to.be.string('Unauthorized');
-
-        done();
-      });
-    });
-
-    it('basic/cookie - switch only client - should return -32602 Unauthorized', function (done) {
-      server.setAuthType('basic');
-      client.setAuthType('basic');
-
-      var params = ['Hello! Mixed Authorization'];
-
-      client.call('echo', params, function (err, result) {
-        if (err) {
-          return done(new Error(JSON.stringify(err)));
-        }
-
-        expect(JSON.stringify(result)).to.be.string(params[0]);
-
-        // Switch Auth Type Only for the Client
+      'cookie/bearer(jwt) - switch only client - should return -32602 Unauthorized': function (done) {
+        server.setAuthType('cookie');
         client.setAuthType('cookie');
 
-        // Should return Unauthorized
+        var params = ['Hello! Mixed Authorization'];
+
         client.call('echo', params, function (err, result) {
-          expect(result).to.equal(undefined);
-          expect(err.code).to.equal((new Errors.InvalidParams()).code);
-          expect(err.message).to.be.string('Unauthorized');
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
 
-          done();
+          expect(JSON.stringify(result)).to.be.string(params[0]);
+
+          // Switch Auth Type Only for the Client
+          client.setAuthType('jwt');
+
+          // Should return Unauthorized
+          client.call('echo', params, function (err, result) {
+            expect(result).to.equal(undefined);
+            expect(err.code).to.equal((new Errors.InvalidParams()).code);
+            expect(err.message).to.be.string('Unauthorized');
+
+            done();
+          });
         });
-      });
-    });
+      },
 
-    it('basic/cookie - switch only server - should return -32602 Unauthorized', function (done) {
-      server.setAuthType('basic');
-      client.setAuthType('basic');
-
-      var params = ['Hello! Mixed Authorization'];
-
-      client.call('echo', params, function (err, result) {
-        if (err) {
-          return done(new Error(JSON.stringify(err)));
-        }
-
-        expect(JSON.stringify(result)).to.be.string(params[0]);
-
-        // Switch Auth Type Only for the Server
+      'cookie/bearer(jwt) - switch only server - should return -32602 Unauthorized': function (done) {
         server.setAuthType('cookie');
+        client.setAuthType('cookie');
 
-        // Should return Unauthorized
-        client.call('echo', params, function (err, result) {
-          expect(result).to.equal(undefined);
-          expect(err.code).to.equal((new Errors.InvalidParams()).code);
-          expect(err.message).to.be.string('Unauthorized');
-
-          done();
-        });
-      });
-    });
-
-    it('basic/bearer(jwt) - switch both - should return 200 OK', function (done) {
-      server.setAuthType('basic');
-      client.setAuthType('basic');
-
-      var params = ['Hello! Mixed Authorization'];
-
-      // We MUST enable promises on the call method!!!
-      client.call('echo', params, function (err, result) {
-        if (err) {
-          return done(new Error(JSON.stringify(err)));
-        }
-
-        expect(JSON.stringify(result)).to.be.string(params[0]);
-
-        // Switch Auth Type
-        server.setAuthType('jwt');
-        client.setAuthType('jwt');
+        var params = ['Hello! Mixed Authorization'];
 
         client.call('echo', params, function (err, result) {
           if (err) {
@@ -474,177 +621,19 @@ describe('Json-Rpc2 Authorization -', function () {
 
           expect(JSON.stringify(result)).to.be.string(params[0]);
 
-          done();
+          // Switch Auth Type Only for the Server
+          server.setAuthType('jwt');
+
+          // Should return Unauthorized
+          client.call('echo', params, function (err, result) {
+            expect(result).to.equal(undefined);
+            expect(err.code).to.equal((new Errors.InvalidParams()).code);
+            expect(err.message).to.be.string('Unauthorized');
+
+            done();
+          });
         });
-      });
-    });
-
-    it('basic/bearer(jwt) - different type - should return -32602 Unauthorized', function (done) {
-      server.setAuthType('basic');
-      client.setAuthType('jwt');
-
-      var params = ['Hello! Mixed Authorization'];
-
-      client.call('echo', params, function (err, result) {
-        expect(result).to.equal(undefined);
-        expect(err.code).to.equal((new Errors.InvalidParams()).code);
-        expect(err.message).to.be.string('Unauthorized');
-
-        done();
-      });
-    });
-
-    it('basic/bearer(jwt) - switch only client - should return -32602 Unauthorized', function (done) {
-      server.setAuthType('basic');
-      client.setAuthType('basic');
-
-      var params = ['Hello! Mixed Authorization'];
-
-      client.call('echo', params, function (err, result) {
-        if (err) {
-          return done(new Error(JSON.stringify(err)));
-        }
-
-        expect(JSON.stringify(result)).to.be.string(params[0]);
-
-        // Switch Auth Type Only for the Client
-        client.setAuthType('jwt');
-
-        // Should return Unauthorized
-        client.call('echo', params, function (err, result) {
-          expect(result).to.equal(undefined);
-          expect(err.code).to.equal((new Errors.InvalidParams()).code);
-          expect(err.message).to.be.string('Unauthorized');
-
-          done();
-        });
-      });
-    });
-
-    it('basic/bearer(jwt) - switch only server - should return -32602 Unauthorized', function (done) {
-      server.setAuthType('basic');
-      client.setAuthType('basic');
-
-      var params = ['Hello! Mixed Authorization'];
-
-      client.call('echo', params, function (err, result) {
-        if (err) {
-          return done(new Error(JSON.stringify(err)));
-        }
-
-        expect(JSON.stringify(result)).to.be.string(params[0]);
-
-        // Switch Auth Type Only for the Server
-        server.setAuthType('jwt');
-
-        // Should return Unauthorized
-        client.call('echo', params, function (err, result) {
-          expect(result).to.equal(undefined);
-          expect(err.code).to.equal((new Errors.InvalidParams()).code);
-          expect(err.message).to.be.string('Unauthorized');
-
-          done();
-        });
-      });
-    });
-
-    it('cookie/bearer(jwt) - switch both - should return 200 OK', function (done) {
-      server.setAuthType('cookie');
-      client.setAuthType('cookie');
-
-      var params = ['Hello! Mixed Authorization'];
-
-      // We MUST enable promises on the call method!!!
-      client.call('echo', params, function (err, result) {
-        if (err) {
-          return done(new Error(JSON.stringify(err)));
-        }
-
-        expect(JSON.stringify(result)).to.be.string(params[0]);
-
-        // Switch Auth Type
-        server.setAuthType('jwt');
-        client.setAuthType('jwt');
-
-        client.call('echo', params, function (err, result) {
-          if (err) {
-            return done(new Error(JSON.stringify(err)));
-          }
-
-          expect(JSON.stringify(result)).to.be.string(params[0]);
-
-          done();
-        });
-      });
-    });
-
-    it('cookie/bearer(jwt) - different type - should return -32602 Unauthorized', function (done) {
-      server.setAuthType('cookie');
-      client.setAuthType('jwt');
-
-      var params = ['Hello! Mixed Authorization'];
-
-      client.call('echo', params, function (err, result) {
-        expect(result).to.equal(undefined);
-        expect(err.code).to.equal((new Errors.InvalidParams()).code);
-        expect(err.message).to.be.string('Unauthorized');
-
-        done();
-      });
-    });
-
-    it('cookie/bearer(jwt) - switch only client - should return -32602 Unauthorized', function (done) {
-      server.setAuthType('cookie');
-      client.setAuthType('cookie');
-
-      var params = ['Hello! Mixed Authorization'];
-
-      client.call('echo', params, function (err, result) {
-        if (err) {
-          return done(new Error(JSON.stringify(err)));
-        }
-
-        expect(JSON.stringify(result)).to.be.string(params[0]);
-
-        // Switch Auth Type Only for the Client
-        client.setAuthType('jwt');
-
-        // Should return Unauthorized
-        client.call('echo', params, function (err, result) {
-          expect(result).to.equal(undefined);
-          expect(err.code).to.equal((new Errors.InvalidParams()).code);
-          expect(err.message).to.be.string('Unauthorized');
-
-          done();
-        });
-      });
-    });
-
-    it('cookie/bearer(jwt) - switch only server - should return -32602 Unauthorized', function (done) {
-      server.setAuthType('cookie');
-      client.setAuthType('cookie');
-
-      var params = ['Hello! Mixed Authorization'];
-
-      client.call('echo', params, function (err, result) {
-        if (err) {
-          return done(new Error(JSON.stringify(err)));
-        }
-
-        expect(JSON.stringify(result)).to.be.string(params[0]);
-
-        // Switch Auth Type Only for the Server
-        server.setAuthType('jwt');
-
-        // Should return Unauthorized
-        client.call('echo', params, function (err, result) {
-          expect(result).to.equal(undefined);
-          expect(err.code).to.equal((new Errors.InvalidParams()).code);
-          expect(err.message).to.be.string('Unauthorized');
-
-          done();
-        });
-      });
-    });
-  });
-});
+      }
+    }
+  }
+};

--- a/test/jsonrpc-test-authorization.js
+++ b/test/jsonrpc-test-authorization.js
@@ -1,0 +1,650 @@
+'use strict';
+
+var
+  expect = require('expect.js'),
+  rpc = require('../src/jsonrpc.js'),
+  Errors = rpc.Error,
+  server, client, serverHandle;
+
+describe('Json-Rpc2 Authorization -', function () {
+  describe('Deprecated Basic -', function () {
+    beforeEach(function () {
+      // Server
+      server = rpc.Server.$create({
+        websocket: true
+      });
+
+      server.expose('echo', function (args, opts, callback) {
+        // callback(err, result)
+        callback(null, args[0]);
+      });
+
+      serverHandle = server.listen(8088, 'localhost');
+      // Deprecated Authorization
+      server.enableAuth('user', 'pass');
+    });
+
+    afterEach(function () {
+      serverHandle.close();
+      serverHandle = null;
+      server = null;
+      client = null;
+    });
+
+    it('client constructor - should return 200 OK', function (done) {
+      // Client
+      client = rpc.Client.$create(8088, 'localhost', 'user', 'pass');
+      var message = ['Hello, Authorization!'];
+
+      client.call('echo', message, function (err, result) {
+        if (err) {
+          return done(new Error(JSON.stringify(err)));
+        }
+
+        expect(JSON.stringify(result)).to.be.string(message[0]);
+
+        done();
+      });
+    });
+
+    it('client constructor - should return -32602 Unauthorized', function (done) {
+      // Client
+      client = rpc.Client.$create(8088, 'localhost', 'wrong-user', 'wrong-pass');
+      var message = ['Hello, Authorization!'];
+
+      client.call('echo', message, function (err, result) {
+        expect(result).to.equal(undefined);
+        expect(err.code).to.equal((new Errors.InvalidParams()).code);
+        expect(err.message).to.be.string('Unauthorized');
+
+        done();
+      });
+    });
+
+    it('client basicAuth function - should return 200 OK', function (done) {
+      // Client
+      client = rpc.Client.$create(8088, 'localhost');
+      client.basicAuth('user', 'pass');
+      var message = ['Hello, Authorization!'];
+
+      client.call('echo', message, function (err, result) {
+        if (err) {
+          return done(new Error(JSON.stringify(err)));
+        }
+
+        expect(JSON.stringify(result)).to.be.string(message[0]);
+
+        done();
+      });
+    });
+
+    it('client basicAuth function - should return -32602 Unauthorized', function (done) {
+      // Client
+      client = rpc.Client.$create(8088, 'localhost');
+      client.basicAuth('wrong-user', 'wrong-pass');
+      var message = ['Hello, Authorization!'];
+
+      client.call('echo', message, function (err, result) {
+        expect(result).to.equal(undefined);
+        expect(err.code).to.equal((new Errors.InvalidParams()).code);
+        expect(err.message).to.be.string('Unauthorized');
+
+        done();
+      });
+
+    });
+  });
+
+  describe('Basic -', function () {
+    beforeEach(function () {
+      // Server
+      server = rpc.Server.$create({
+        websocket: true
+      });
+
+      server.expose('echo', function (args, opts, callback) {
+        // callback(err, result)
+        callback(null, args[0]);
+      });
+
+      serverHandle = server.listen(8088, 'localhost');
+      // Basic Authorization
+      server.enableBasicAuth('user', 'pass');
+    });
+
+    afterEach(function () {
+      serverHandle.close();
+      serverHandle = null;
+      server = null;
+      client = null;
+    });
+
+    it('client constructor - should return 200 OK', function (done) {
+      // Client
+      client = rpc.Client.$create(8088, 'localhost', 'user', 'pass');
+      var message = ['Hello, Authorization!'];
+
+      client.call('echo', message, function (err, result) {
+        if (err) {
+          return done(new Error(JSON.stringify(err)));
+        }
+
+        expect(JSON.stringify(result)).to.be.string(message[0]);
+
+        done();
+      });
+    });
+
+    it('client constructor - should return -32602 Unauthorized', function (done) {
+      // Client
+      client = rpc.Client.$create(8088, 'localhost', 'wrong-user', 'wrong-pass');
+      var message = ['Hello, Authorization!'];
+
+      client.call('echo', message, function (err, result) {
+        expect(result).to.equal(undefined);
+        expect(err.code).to.equal((new Errors.InvalidParams()).code);
+        expect(err.message).to.be.string('Unauthorized');
+
+        done();
+      });
+    });
+
+    it('client basicAuth function - should return 200 OK', function (done) {
+      // Client
+      client = rpc.Client.$create(8088, 'localhost');
+      client.basicAuth('user', 'pass');
+      var message = ['Hello, Authorization!'];
+
+      client.call('echo', message, function (err, result) {
+        if (err) {
+          return done(new Error(JSON.stringify(err)));
+        }
+
+        expect(JSON.stringify(result)).to.be.string(message[0]);
+
+        done();
+      });
+    });
+
+    it('client basicAuth function - should return -32602 Unauthorized', function (done) {
+      // Client
+      client = rpc.Client.$create(8088, 'localhost');
+      client.basicAuth('wrong-user', 'wrong-pass');
+      var message = ['Hello, Authorization!'];
+
+      client.call('echo', message, function (err, result) {
+        expect(result).to.equal(undefined);
+        expect(err.code).to.equal((new Errors.InvalidParams()).code);
+        expect(err.message).to.be.string('Unauthorized');
+
+        done();
+      });
+
+    });
+  });
+
+  describe('Cookie -', function () {
+    beforeEach(function () {
+      // Server
+      server = rpc.Server.$create({
+        websocket: true
+      });
+
+      server.expose('echo', function (args, opts, callback) {
+        // callback(err, result)
+        callback(null, args[0]);
+      });
+
+      serverHandle = server.listen(8088, 'localhost');
+      // Cookie Authorization
+      server.enableCookieAuth(function (cookieValue) {
+        if (cookieValue === 'validCookieValue') {
+          return true;
+        }
+        return false;
+      });
+    });
+
+    afterEach(function () {
+      serverHandle.close();
+      serverHandle = null;
+      server = null;
+      client = null;
+    });
+
+    it('client cookieAuth function - should return 200 OK', function (done) {
+      // Client
+      client = rpc.Client.$create(8088, 'localhost');
+      client.cookieAuth('validCookieValue');
+      var message = ['Hello, Authorization!'];
+
+      client.call('echo', message, function (err, result) {
+        if (err) {
+          return done(new Error(JSON.stringify(err)));
+        }
+
+        expect(JSON.stringify(result)).to.be.string(message[0]);
+
+        done();
+      });
+    });
+
+    it('client cookieAuth function - should return -32602 Unauthorized', function (done) {
+      // Client
+      client = rpc.Client.$create(8088, 'localhost');
+      client.cookieAuth('wrongCookieValue');
+      var message = ['Hello, Authorization!'];
+
+      client.call('echo', message, function (err, result) {
+        expect(result).to.equal(undefined);
+        expect(err.code).to.equal((new Errors.InvalidParams()).code);
+        expect(err.message).to.be.string('Unauthorized');
+
+        done();
+      });
+
+    });
+  });
+
+  describe('Bearer (JWT) -', function () {
+    beforeEach(function () {
+      // Server
+      server = rpc.Server.$create({
+        websocket: true
+      });
+
+      server.expose('echo', function (args, opts, callback) {
+        // callback(err, result)
+        callback(null, args[0]);
+      });
+
+      serverHandle = server.listen(8088, 'localhost');
+      // Bearer (JWT) Authorization
+      server.enableJWTAuth(function (tokenValue) {
+        if (tokenValue === 'validTokenValue') {
+          return true;
+        }
+        return false;
+      });
+    });
+
+    afterEach(function () {
+      serverHandle.close();
+      serverHandle = null;
+      server = null;
+      client = null;
+    });
+
+    it('client cookieAuth function - should return 200 OK', function (done) {
+      // Client
+      client = rpc.Client.$create(8088, 'localhost');
+      client.jwtAuth('validTokenValue');
+      var message = ['Hello, Authorization!'];
+
+      client.call('echo', message, function (err, result) {
+        if (err) {
+          return done(new Error(JSON.stringify(err)));
+        }
+
+        expect(JSON.stringify(result)).to.be.string(message[0]);
+
+        done();
+      });
+    });
+
+    it('client cookieAuth function - should return -32602 Unauthorized', function (done) {
+      // Client
+      client = rpc.Client.$create(8088, 'localhost');
+      client.jwtAuth('wrongTokenValue');
+      var message = ['Hello, Authorization!'];
+
+      client.call('echo', message, function (err, result) {
+        expect(result).to.equal(undefined);
+        expect(err.code).to.equal((new Errors.InvalidParams()).code);
+        expect(err.message).to.be.string('Unauthorized');
+
+        done();
+      });
+
+    });
+  });
+
+  describe('Mixed -', function () {
+    beforeEach(function () {
+      server = rpc.Server.$create({
+        websocket: true
+      });
+
+      server.expose('echo', function (args, opts, callback) {
+        callback(null, args[0]);
+      });
+
+      serverHandle = server.listen(8088, 'localhost');
+
+      // Server Authorization
+      server.enableBasicAuth('user', 'pass');
+      server.enableCookieAuth(function (cookieValue) {
+        if (cookieValue === 'validCookieValue') {
+          return true;
+        }
+        return false;
+      });
+      server.enableJWTAuth(function (tokenValue) {
+        if (tokenValue === 'validTokenValue') {
+          return true;
+        }
+        return false;
+      });
+
+      // Client Authorization
+      client = rpc.Client.$create(8088, 'localhost');
+      client.basicAuth('user', 'pass');
+      client.cookieAuth('validCookieValue');
+      client.jwtAuth('validTokenValue');
+    });
+
+    afterEach(function () {
+      serverHandle.close();
+      serverHandle = null;
+      server = null;
+      client = null;
+    });
+
+    it('basic/cookie - switch both - should return 200 OK', function (done) {
+      server.setAuthType('basic');
+      client.setAuthType('basic');
+
+      var params = ['Hello! Mixed Authorization'];
+
+      // We MUST enable promises on the call method!!!
+      client.call('echo', params, function (err, result) {
+        if (err) {
+          return done(new Error(JSON.stringify(err)));
+        }
+
+        expect(JSON.stringify(result)).to.be.string(params[0]);
+
+        // Switch Auth Type (would look better to have promises here)
+        server.setAuthType('cookie');
+        client.setAuthType('cookie');
+
+        client.call('echo', params, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(params[0]);
+
+          done();
+        });
+      });
+    });
+
+    it('basic/cookie - different type - should return -32602 Unauthorized', function (done) {
+      server.setAuthType('basic');
+      client.setAuthType('cookie');
+
+      var params = ['Hello! Mixed Authorization'];
+
+      client.call('echo', params, function (err, result) {
+        expect(result).to.equal(undefined);
+        expect(err.code).to.equal((new Errors.InvalidParams()).code);
+        expect(err.message).to.be.string('Unauthorized');
+
+        done();
+      });
+    });
+
+    it('basic/cookie - switch only client - should return -32602 Unauthorized', function (done) {
+      server.setAuthType('basic');
+      client.setAuthType('basic');
+
+      var params = ['Hello! Mixed Authorization'];
+
+      client.call('echo', params, function (err, result) {
+        if (err) {
+          return done(new Error(JSON.stringify(err)));
+        }
+
+        expect(JSON.stringify(result)).to.be.string(params[0]);
+
+        // Switch Auth Type Only for the Client
+        client.setAuthType('cookie');
+
+        // Should return Unauthorized
+        client.call('echo', params, function (err, result) {
+          expect(result).to.equal(undefined);
+          expect(err.code).to.equal((new Errors.InvalidParams()).code);
+          expect(err.message).to.be.string('Unauthorized');
+
+          done();
+        });
+      });
+    });
+
+    it('basic/cookie - switch only server - should return -32602 Unauthorized', function (done) {
+      server.setAuthType('basic');
+      client.setAuthType('basic');
+
+      var params = ['Hello! Mixed Authorization'];
+
+      client.call('echo', params, function (err, result) {
+        if (err) {
+          return done(new Error(JSON.stringify(err)));
+        }
+
+        expect(JSON.stringify(result)).to.be.string(params[0]);
+
+        // Switch Auth Type Only for the Server
+        server.setAuthType('cookie');
+
+        // Should return Unauthorized
+        client.call('echo', params, function (err, result) {
+          expect(result).to.equal(undefined);
+          expect(err.code).to.equal((new Errors.InvalidParams()).code);
+          expect(err.message).to.be.string('Unauthorized');
+
+          done();
+        });
+      });
+    });
+
+    it('basic/bearer(jwt) - switch both - should return 200 OK', function (done) {
+      server.setAuthType('basic');
+      client.setAuthType('basic');
+
+      var params = ['Hello! Mixed Authorization'];
+
+      // We MUST enable promises on the call method!!!
+      client.call('echo', params, function (err, result) {
+        if (err) {
+          return done(new Error(JSON.stringify(err)));
+        }
+
+        expect(JSON.stringify(result)).to.be.string(params[0]);
+
+        // Switch Auth Type
+        server.setAuthType('jwt');
+        client.setAuthType('jwt');
+
+        client.call('echo', params, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(params[0]);
+
+          done();
+        });
+      });
+    });
+
+    it('basic/bearer(jwt) - different type - should return -32602 Unauthorized', function (done) {
+      server.setAuthType('basic');
+      client.setAuthType('jwt');
+
+      var params = ['Hello! Mixed Authorization'];
+
+      client.call('echo', params, function (err, result) {
+        expect(result).to.equal(undefined);
+        expect(err.code).to.equal((new Errors.InvalidParams()).code);
+        expect(err.message).to.be.string('Unauthorized');
+
+        done();
+      });
+    });
+
+    it('basic/bearer(jwt) - switch only client - should return -32602 Unauthorized', function (done) {
+      server.setAuthType('basic');
+      client.setAuthType('basic');
+
+      var params = ['Hello! Mixed Authorization'];
+
+      client.call('echo', params, function (err, result) {
+        if (err) {
+          return done(new Error(JSON.stringify(err)));
+        }
+
+        expect(JSON.stringify(result)).to.be.string(params[0]);
+
+        // Switch Auth Type Only for the Client
+        client.setAuthType('jwt');
+
+        // Should return Unauthorized
+        client.call('echo', params, function (err, result) {
+          expect(result).to.equal(undefined);
+          expect(err.code).to.equal((new Errors.InvalidParams()).code);
+          expect(err.message).to.be.string('Unauthorized');
+
+          done();
+        });
+      });
+    });
+
+    it('basic/bearer(jwt) - switch only server - should return -32602 Unauthorized', function (done) {
+      server.setAuthType('basic');
+      client.setAuthType('basic');
+
+      var params = ['Hello! Mixed Authorization'];
+
+      client.call('echo', params, function (err, result) {
+        if (err) {
+          return done(new Error(JSON.stringify(err)));
+        }
+
+        expect(JSON.stringify(result)).to.be.string(params[0]);
+
+        // Switch Auth Type Only for the Server
+        server.setAuthType('jwt');
+
+        // Should return Unauthorized
+        client.call('echo', params, function (err, result) {
+          expect(result).to.equal(undefined);
+          expect(err.code).to.equal((new Errors.InvalidParams()).code);
+          expect(err.message).to.be.string('Unauthorized');
+
+          done();
+        });
+      });
+    });
+
+    it('cookie/bearer(jwt) - switch both - should return 200 OK', function (done) {
+      server.setAuthType('cookie');
+      client.setAuthType('cookie');
+
+      var params = ['Hello! Mixed Authorization'];
+
+      // We MUST enable promises on the call method!!!
+      client.call('echo', params, function (err, result) {
+        if (err) {
+          return done(new Error(JSON.stringify(err)));
+        }
+
+        expect(JSON.stringify(result)).to.be.string(params[0]);
+
+        // Switch Auth Type
+        server.setAuthType('jwt');
+        client.setAuthType('jwt');
+
+        client.call('echo', params, function (err, result) {
+          if (err) {
+            return done(new Error(JSON.stringify(err)));
+          }
+
+          expect(JSON.stringify(result)).to.be.string(params[0]);
+
+          done();
+        });
+      });
+    });
+
+    it('cookie/bearer(jwt) - different type - should return -32602 Unauthorized', function (done) {
+      server.setAuthType('cookie');
+      client.setAuthType('jwt');
+
+      var params = ['Hello! Mixed Authorization'];
+
+      client.call('echo', params, function (err, result) {
+        expect(result).to.equal(undefined);
+        expect(err.code).to.equal((new Errors.InvalidParams()).code);
+        expect(err.message).to.be.string('Unauthorized');
+
+        done();
+      });
+    });
+
+    it('cookie/bearer(jwt) - switch only client - should return -32602 Unauthorized', function (done) {
+      server.setAuthType('cookie');
+      client.setAuthType('cookie');
+
+      var params = ['Hello! Mixed Authorization'];
+
+      client.call('echo', params, function (err, result) {
+        if (err) {
+          return done(new Error(JSON.stringify(err)));
+        }
+
+        expect(JSON.stringify(result)).to.be.string(params[0]);
+
+        // Switch Auth Type Only for the Client
+        client.setAuthType('jwt');
+
+        // Should return Unauthorized
+        client.call('echo', params, function (err, result) {
+          expect(result).to.equal(undefined);
+          expect(err.code).to.equal((new Errors.InvalidParams()).code);
+          expect(err.message).to.be.string('Unauthorized');
+
+          done();
+        });
+      });
+    });
+
+    it('cookie/bearer(jwt) - switch only server - should return -32602 Unauthorized', function (done) {
+      server.setAuthType('cookie');
+      client.setAuthType('cookie');
+
+      var params = ['Hello! Mixed Authorization'];
+
+      client.call('echo', params, function (err, result) {
+        if (err) {
+          return done(new Error(JSON.stringify(err)));
+        }
+
+        expect(JSON.stringify(result)).to.be.string(params[0]);
+
+        // Switch Auth Type Only for the Server
+        server.setAuthType('jwt');
+
+        // Should return Unauthorized
+        client.call('echo', params, function (err, result) {
+          expect(result).to.equal(undefined);
+          expect(err.code).to.equal((new Errors.InvalidParams()).code);
+          expect(err.message).to.be.string('Unauthorized');
+
+          done();
+        });
+      });
+    });
+  });
+});

--- a/test/jsonrpc-test-authorization.js
+++ b/test/jsonrpc-test-authorization.js
@@ -20,6 +20,10 @@ module.exports = {
           callback(null, args[0]);
         });
 
+        server.expose('throw_error', function (args, opts, callback) {
+          throw new Errors.InternalError();
+        });
+
         serverHandle = server.listen(8088, 'localhost');
         // Deprecated Authorization
         server.enableAuth('user', 'pass');
@@ -31,7 +35,20 @@ module.exports = {
         server = null;
         client = null;
       },
+      
+      'check throw error - should return 200 OK': function (done) {
+        // Client
+        client = rpc.Client.$create(8088, 'localhost', 'user', 'pass');
+        var message = ['Hello, Authorization!'];
 
+        client.call('throw_error', message, function (err, result) {
+          expect(err.code).to.equal((new Errors.InternalError()).code);
+          expect(err.message).to.be.string('InternalError');
+
+          done();
+        });
+      },
+      
       'client constructor - should return 200 OK': function (done) {
         // Client
         client = rpc.Client.$create(8088, 'localhost', 'user', 'pass');
@@ -61,7 +78,7 @@ module.exports = {
           done();
         });
       },
-
+      
       'client basicAuth function - should return 200 OK': function (done) {
         // Client
         client = rpc.Client.$create(8088, 'localhost');
@@ -633,7 +650,7 @@ module.exports = {
             done();
           });
         });
-      }
+      }      
     }
   }
 };

--- a/test/jsonrpc-test.js
+++ b/test/jsonrpc-test.js
@@ -6,7 +6,7 @@ var
   server, MockRequest, MockResponse, testBadRequest, TestModule, echo;
 
 module.exports = {
-  jsonRpcTest: {
+  'jsonRpcTest': {
     beforeEach: function () {
       server = rpc.Server.$create();
 

--- a/test/jsonrpc-test.js
+++ b/test/jsonrpc-test.js
@@ -23,7 +23,7 @@ module.exports = {
       };
       server.expose('echo', echo);
 
-      var throw_error = function () {
+      var throw_error = function (args, opts, callback) {
         throw new rpc.Error.InternalError();
       };
       server.expose('throw_error', throw_error);
@@ -133,7 +133,7 @@ module.exports = {
         expect(decoded.error.code).to.equal(-32603);
       },
 //      text_error javascript_error
-
+      
       'Missing object attribute (method)': function (done) {
         var testJSON = '{ "params": ["Hello, World!"], "id": 1 }';
         testBadRequest(testJSON, done);

--- a/test/jsonrpc-test.js
+++ b/test/jsonrpc-test.js
@@ -6,264 +6,268 @@ var
   server, MockRequest, MockResponse, testBadRequest, TestModule, echo;
 
 module.exports = {
-  beforeEach     : function (){
-    server = rpc.Server.$create();
+  jsonRpcTest: {
+    beforeEach: function () {
+      server = rpc.Server.$create();
 
-    // MOCK REQUEST/RESPONSE OBJECTS
-    MockRequest = rpc.EventEmitter.$define('MockRequest', {
-      construct: function($super, method){
-        $super();
-        this.method = method;
-      }
-    });
+      // MOCK REQUEST/RESPONSE OBJECTS
+      MockRequest = rpc.EventEmitter.$define('MockRequest', {
+        construct: function ($super, method) {
+          $super();
+          this.method = method;
+        }
+      });
 
-    echo = function (args, opts, callback){
-      callback(null, args[0]);
-    };
-    server.expose('echo', echo);
+      echo = function (args, opts, callback) {
+        callback(null, args[0]);
+      };
+      server.expose('echo', echo);
 
-    var throw_error = function (){
-      throw new rpc.Error.InternalError();
-    };
-    server.expose('throw_error', throw_error);
+      var throw_error = function () {
+        throw new rpc.Error.InternalError();
+      };
+      server.expose('throw_error', throw_error);
 
-    var json_rpc_error = function (args, opts, callback){
-      callback(new rpc.Error.InternalError(), args[0]);
-    };
-    server.expose('json_rpc_error', json_rpc_error);
+      var json_rpc_error = function (args, opts, callback) {
+        callback(new rpc.Error.InternalError(), args[0]);
+      };
+      server.expose('json_rpc_error', json_rpc_error);
 
-    var text_error = function (args, opts, callback){
-      callback('error', args[0]);
-    };
-    server.expose('text_error', text_error);
+      var text_error = function (args, opts, callback) {
+        callback('error', args[0]);
+      };
+      server.expose('text_error', text_error);
 
-    var javascript_error = function (args, opts, callback){
-      callback(new Error(), args[0]);
-    };
+      var javascript_error = function (args, opts, callback) {
+        callback(new Error(), args[0]);
+      };
 
-    server.expose('javascript_error', javascript_error);
+      server.expose('javascript_error', javascript_error);
 
-    MockResponse = rpc.EventEmitter.$define('MockResponse', {
-      construct: function($super){
-        $super();
+      MockResponse = rpc.EventEmitter.$define('MockResponse', {
+        construct: function ($super) {
+          $super();
 
-        this.writeHead = this.sendHeader = function (httpCode){
-          this.httpCode = httpCode;
-          this.httpHeaders = httpCode;
-        };
-        this.write = this.sendBody = function (httpBody){
-          this.httpBody = httpBody;
-        };
-        this.end = this.finish = function (){};
-        this.connection = new rpc.EventEmitter();
-      }
-    });
+          this.writeHead = this.sendHeader = function (httpCode) {
+            this.httpCode = httpCode;
+            this.httpHeaders = httpCode;
+          };
+          this.write = this.sendBody = function (httpBody) {
+            this.httpBody = httpBody;
+          };
+          this.end = this.finish = function () {
+          };
+          this.connection = new rpc.EventEmitter();
+        }
+      });
 
 
-    // A SIMPLE MODULE
-    TestModule = {
-      foo: function (a, b){
-        return ['foo', 'bar', a, b];
-      },
+      // A SIMPLE MODULE
+      TestModule = {
+        foo: function (a, b) {
+          return ['foo', 'bar', a, b];
+        },
 
-      other: 'hello'
-    };
+        other: 'hello'
+      };
 
-    testBadRequest = function (testJSON, done){
-      var req = new MockRequest('POST');
-      var res = new MockResponse();
-      server.handleHttp(req, res);
-      req.emit('data', testJSON);
-      req.emit('end');
-      var decoded = JSON.parse(res.httpBody);
-      expect(decoded.id).to.equal(null);
-      expect(decoded.error.message).to.equal('Invalid Request');
-      expect(decoded.error.code).to.equal(-32600);
-      done();
-    };
-  },
-  afterEach: function(){
+      testBadRequest = function (testJSON, done) {
+        var req = new MockRequest('POST');
+        var res = new MockResponse();
+        server.handleHttp(req, res);
+        req.emit('data', testJSON);
+        req.emit('end');
+        var decoded = JSON.parse(res.httpBody);
+        expect(decoded.id).to.equal(null);
+        expect(decoded.error.message).to.equal('Invalid Request');
+        expect(decoded.error.code).to.equal(-32600);
+        done();
+      };
+    },
+    afterEach: function () {
       server = null;
       MockRequest = null;
       MockResponse = null;
       testBadRequest = null;
       TestModule = null;
-  },
-  'json-rpc2': {
-    'Server expose': function (){
-      expect(server.functions.echo).to.eql(echo);
     },
+    'json-rpc2': {
+      'Server expose': function () {
+        expect(server.functions.echo).to.eql(echo);
+      },
 
-    'Server exposeModule': function (){
-      server.exposeModule('test', TestModule);
-      expect(server.functions['test.foo']).to.eql(TestModule.foo);
-    },
+      'Server exposeModule': function () {
+        server.exposeModule('test', TestModule);
+        expect(server.functions['test.foo']).to.eql(TestModule.foo);
+      },
 
-    'GET Server handle NonPOST': function (){
-      var req = new MockRequest('GET');
-      var res = new MockResponse();
-      server.handleHttp(req, res);
-      var decoded = JSON.parse(res.httpBody);
-      expect(decoded.id).to.equal(null);
-      expect(decoded.error.message).to.equal('Invalid Request');
-      expect(decoded.error.code).to.equal(-32600);
-    },
-    'Method throw an error' : function() {
-      var req = new MockRequest('POST');
-      var res = new MockResponse();
-      server.handleHttp(req, res);
-      req.emit('data', '{ "method": "throw_error", "params": [], "id": 1 }');
-      req.emit('end');
-      var decoded = JSON.parse(res.httpBody);
-      expect(decoded.id).to.equal(1);
-      expect(decoded.error.message).to.equal('InternalError');
-      expect(decoded.error.code).to.equal(-32603);
-    },
-    'Method return an rpc error' : function() {
-      var req = new MockRequest('POST');
-      var res = new MockResponse();
-      server.handleHttp(req, res);
-      req.emit('data', '{ "method": "json_rpc_error", "params": [], "id": 1 }');
-      req.emit('end');
-      var decoded = JSON.parse(res.httpBody);
-      expect(decoded.id).to.equal(1);
-      expect(decoded.error.message).to.equal('InternalError');
-      expect(decoded.error.code).to.equal(-32603);
-    },
+      'GET Server handle NonPOST': function () {
+        var req = new MockRequest('GET');
+        var res = new MockResponse();
+        server.handleHttp(req, res);
+        var decoded = JSON.parse(res.httpBody);
+        expect(decoded.id).to.equal(null);
+        expect(decoded.error.message).to.equal('Invalid Request');
+        expect(decoded.error.code).to.equal(-32600);
+      },
+      'Method throw an error': function () {
+        var req = new MockRequest('POST');
+        var res = new MockResponse();
+        server.handleHttp(req, res);
+        req.emit('data', '{ "method": "throw_error", "params": [], "id": 1 }');
+        req.emit('end');
+        var decoded = JSON.parse(res.httpBody);
+        expect(decoded.id).to.equal(1);
+        expect(decoded.error.message).to.equal('InternalError');
+        expect(decoded.error.code).to.equal(-32603);
+      },
+      'Method return an rpc error': function () {
+        var req = new MockRequest('POST');
+        var res = new MockResponse();
+        server.handleHttp(req, res);
+        req.emit('data', '{ "method": "json_rpc_error", "params": [], "id": 1 }');
+        req.emit('end');
+        var decoded = JSON.parse(res.httpBody);
+        expect(decoded.id).to.equal(1);
+        expect(decoded.error.message).to.equal('InternalError');
+        expect(decoded.error.code).to.equal(-32603);
+      },
 //      text_error javascript_error
 
-    'Missing object attribute (method)': function (done){
-      var testJSON = '{ "params": ["Hello, World!"], "id": 1 }';
-      testBadRequest(testJSON, done);
-    },
+      'Missing object attribute (method)': function (done) {
+        var testJSON = '{ "params": ["Hello, World!"], "id": 1 }';
+        testBadRequest(testJSON, done);
+      },
 
-    'Missing object attribute (params)': function (done){
-      var testJSON = '{ "method": "echo", "id": 1 }';
-      testBadRequest(testJSON, done);
-    },
+      'Missing object attribute (params)': function (done) {
+        var testJSON = '{ "method": "echo", "id": 1 }';
+        testBadRequest(testJSON, done);
+      },
 
-    'Unregistered method': function (){
-      var testJSON = '{ "method": "notRegistered", "params": ["Hello, World!"], "id": 1 }';
-      var req = new MockRequest('POST');
-      var res = new MockResponse();
-      try {
+      'Unregistered method': function () {
+        var testJSON = '{ "method": "notRegistered", "params": ["Hello, World!"], "id": 1 }';
+        var req = new MockRequest('POST');
+        var res = new MockResponse();
+        try {
+          server.handleHttp(req, res);
+        } catch (e) {
+        }
+        req.emit('data', testJSON);
+        req.emit('end');
+        expect(res.httpCode).to.equal(200);
+        var decoded = JSON.parse(res.httpBody);
+        expect(decoded.id).to.equal(1);
+        expect(decoded.error.message).to.equal('Unknown RPC call "notRegistered"');
+        expect(decoded.error.code).to.equal(-32601);
+      },
+
+      // VALID REQUEST
+
+      'Simple synchronous echo': function () {
+        var testJSON = '{ "method": "echo", "params": ["Hello, World!"], "id": 1 }';
+        var req = new MockRequest('POST');
+        var res = new MockResponse();
         server.handleHttp(req, res);
-      } catch (e) {}
-      req.emit('data', testJSON);
-      req.emit('end');
-      expect(res.httpCode).to.equal(200);
-      var decoded = JSON.parse(res.httpBody);
-      expect(decoded.id).to.equal(1);
-      expect(decoded.error.message).to.equal('Unknown RPC call "notRegistered"');
-      expect(decoded.error.code).to.equal(-32601);
-    },
+        req.emit('data', testJSON);
+        req.emit('end');
+        expect(res.httpCode).to.equal(200);
+        var decoded = JSON.parse(res.httpBody);
+        expect(decoded.id).to.equal(1);
+        expect(decoded.error).to.equal(undefined);
+        expect(decoded.result).to.equal('Hello, World!');
+      },
 
-    // VALID REQUEST
+      'Simple synchronous echo with id as null': function () {
+        var testJSON = '{ "method": "echo", "params": ["Hello, World!"], "id": null }';
+        var req = new MockRequest('POST');
+        var res = new MockResponse();
+        server.handleHttp(req, res);
+        req.emit('data', testJSON);
+        req.emit('end');
+        expect(res.httpCode).to.equal(200);
+        var decoded = JSON.parse(res.httpBody);
+        expect(decoded.id).to.equal(null);
+        expect(decoded.error).to.equal(undefined);
+        expect(decoded.result).to.equal('Hello, World!');
+      },
 
-    'Simple synchronous echo': function (){
-      var testJSON = '{ "method": "echo", "params": ["Hello, World!"], "id": 1 }';
-      var req = new MockRequest('POST');
-      var res = new MockResponse();
-      server.handleHttp(req, res);
-      req.emit('data', testJSON);
-      req.emit('end');
-      expect(res.httpCode).to.equal(200);
-      var decoded = JSON.parse(res.httpBody);
-      expect(decoded.id).to.equal(1);
-      expect(decoded.error).to.equal(undefined);
-      expect(decoded.result).to.equal('Hello, World!');
-    },
+      'Simple synchronous echo with string as id': function () {
+        var testJSON = '{ "method": "echo", "params": ["Hello, World!"], "id": "test" }';
+        var req = new MockRequest('POST');
+        var res = new MockResponse();
+        server.handleHttp(req, res);
+        req.emit('data', testJSON);
+        req.emit('end');
+        expect(res.httpCode).to.equal(200);
+        var decoded = JSON.parse(res.httpBody);
+        expect(decoded.id).to.equal('test');
+        expect(decoded.error).to.equal(undefined);
+        expect(decoded.result).to.equal('Hello, World!');
+      },
 
-    'Simple synchronous echo with id as null': function (){
-      var testJSON = '{ "method": "echo", "params": ["Hello, World!"], "id": null }';
-      var req = new MockRequest('POST');
-      var res = new MockResponse();
-      server.handleHttp(req, res);
-      req.emit('data', testJSON);
-      req.emit('end');
-      expect(res.httpCode).to.equal(200);
-      var decoded = JSON.parse(res.httpBody);
-      expect(decoded.id).to.equal(null);
-      expect(decoded.error).to.equal(undefined);
-      expect(decoded.result).to.equal('Hello, World!');
-    },
+      'Using promise': function () {
+        // Expose a function that just returns a promise that we can control.
+        var callbackRef = null;
+        server.expose('promiseEcho', function (args, opts, callback) {
+          callbackRef = callback;
+        });
+        // Build a request to call that function
+        var testJSON = '{ "method": "promiseEcho", "params": ["Hello, World!"], "id": 1 }';
+        var req = new MockRequest('POST');
+        var res = new MockResponse();
+        // Have the server handle that request
+        server.handleHttp(req, res);
+        req.emit('data', testJSON);
+        req.emit('end');
+        // Now the request has completed, and in the above synchronous test, we
+        // would be finished. However, this function is smarter and only completes
+        // when the promise completes.  Therefore, we should not have a response
+        // yet.
+        expect(res.httpCode).to.not.be.ok();
+        // We can force the promise to emit a success code, with a message.
+        callbackRef(null, 'Hello, World!');
+        // Aha, now that the promise has finished, our request has finished as well.
+        expect(res.httpCode).to.equal(200);
+        var decoded = JSON.parse(res.httpBody);
+        expect(decoded.id).to.equal(1);
+        expect(decoded.error).to.equal(undefined);
+        expect(decoded.result).to.equal('Hello, World!');
+      },
 
-    'Simple synchronous echo with string as id': function (){
-      var testJSON = '{ "method": "echo", "params": ["Hello, World!"], "id": "test" }';
-      var req = new MockRequest('POST');
-      var res = new MockResponse();
-      server.handleHttp(req, res);
-      req.emit('data', testJSON);
-      req.emit('end');
-      expect(res.httpCode).to.equal(200);
-      var decoded = JSON.parse(res.httpBody);
-      expect(decoded.id).to.equal('test');
-      expect(decoded.error).to.equal(undefined);
-      expect(decoded.result).to.equal('Hello, World!');
-    },
-
-    'Using promise': function (){
-      // Expose a function that just returns a promise that we can control.
-      var callbackRef = null;
-      server.expose('promiseEcho', function (args, opts, callback){
-        callbackRef = callback;
-      });
-      // Build a request to call that function
-      var testJSON = '{ "method": "promiseEcho", "params": ["Hello, World!"], "id": 1 }';
-      var req = new MockRequest('POST');
-      var res = new MockResponse();
-      // Have the server handle that request
-      server.handleHttp(req, res);
-      req.emit('data', testJSON);
-      req.emit('end');
-      // Now the request has completed, and in the above synchronous test, we
-      // would be finished. However, this function is smarter and only completes
-      // when the promise completes.  Therefore, we should not have a response
-      // yet.
-      expect(res.httpCode).to.not.be.ok();
-      // We can force the promise to emit a success code, with a message.
-      callbackRef(null, 'Hello, World!');
-      // Aha, now that the promise has finished, our request has finished as well.
-      expect(res.httpCode).to.equal(200);
-      var decoded = JSON.parse(res.httpBody);
-      expect(decoded.id).to.equal(1);
-      expect(decoded.error).to.equal(undefined);
-      expect(decoded.result).to.equal('Hello, World!');
-    },
-
-    'Triggering an errback': function (){
-      var callbackRef = null;
-      server.expose('errbackEcho', function (args, opts, callback){
-        callbackRef = callback;
-      });
-      var testJSON = '{ "method": "errbackEcho", "params": ["Hello, World!"], "id": 1 }';
-      var req = new MockRequest('POST');
-      var res = new MockResponse();
-      server.handleHttp(req, res);
-      req.emit('data', testJSON);
-      req.emit('end');
-      expect(res.httpCode).to.not.be.ok();
-      // This time, unlike the above test, we trigger an error and expect to see
-      // it in the error attribute of the object returned.
-      callbackRef('This is an error');
-      expect(res.httpCode).to.equal(200);
-      var decoded = JSON.parse(res.httpBody);
-      expect(decoded.id).to.equal(1);
-      expect(decoded.error.message).to.equal('This is an error');
-      expect(decoded.error.code).to.equal(-32603);
-      expect(decoded.result).to.equal(undefined);
-    },
-    'Notification request': function () {
-      var testJSON = '{ "method": "notify_test", "params": ["Hello, World!"] }';
-      var req = new MockRequest('POST');
-      var res = new MockResponse();
-      server.handleHttp(req, res);
-      req.emit('data', testJSON);
-      req.emit('end');
-      // although it shouldn't return a response, we are dealing with HTTP, that MUST
-      // return something, in most cases, 0 length body
-      expect(res.httpCode).to.equal(200);
-      expect(res.httpBody).to.equal('');
+      'Triggering an errback': function () {
+        var callbackRef = null;
+        server.expose('errbackEcho', function (args, opts, callback) {
+          callbackRef = callback;
+        });
+        var testJSON = '{ "method": "errbackEcho", "params": ["Hello, World!"], "id": 1 }';
+        var req = new MockRequest('POST');
+        var res = new MockResponse();
+        server.handleHttp(req, res);
+        req.emit('data', testJSON);
+        req.emit('end');
+        expect(res.httpCode).to.not.be.ok();
+        // This time, unlike the above test, we trigger an error and expect to see
+        // it in the error attribute of the object returned.
+        callbackRef('This is an error');
+        expect(res.httpCode).to.equal(200);
+        var decoded = JSON.parse(res.httpBody);
+        expect(decoded.id).to.equal(1);
+        expect(decoded.error.message).to.equal('This is an error');
+        expect(decoded.error.code).to.equal(-32603);
+        expect(decoded.result).to.equal(undefined);
+      },
+      'Notification request': function () {
+        var testJSON = '{ "method": "notify_test", "params": ["Hello, World!"] }';
+        var req = new MockRequest('POST');
+        var res = new MockResponse();
+        server.handleHttp(req, res);
+        req.emit('data', testJSON);
+        req.emit('end');
+        // although it shouldn't return a response, we are dealing with HTTP, that MUST
+        // return something, in most cases, 0 length body
+        expect(res.httpCode).to.equal(200);
+        expect(res.httpBody).to.equal('');
+      }
     }
   }
 };

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,3 @@
 --reporter list
 --ui exports
 --check-leaks
-test/jsonrpc-test.js


### PR DESCRIPTION
To the implementators and extensions POV, refactoring a standard way using promises in those methods increase testability, interop and easier integrations. It also decouples the functionality that is currently ingrained inside those methods, and expose them for better unit testing

HandleHttp part for #29; HandleRaw remaining. 

Submitting for refactoring and improvements.

Tests were adapted for this implementation.